### PR TITLE
fix: use direct img src for viewer (fixes blank viewer)

### DIFF
--- a/frontend/src/components/Viewer.tsx
+++ b/frontend/src/components/Viewer.tsx
@@ -18,8 +18,6 @@ interface ViewerProps {
 export function Viewer({ photo, onTrimChange }: ViewerProps) {
     const [exif, setExif] = useState<PhotoEXIF | null>(null);
     const videoRef = useRef<HTMLVideoElement>(null);
-    const abortControllerRef = useRef<AbortController | null>(null);
-    const blobUrlRef = useRef<string | null>(null);
     const [imageSrc, setImageSrc] = useState<string>('');
 
     useEffect(() => {
@@ -49,50 +47,15 @@ export function Viewer({ photo, onTrimChange }: ViewerProps) {
         loadExif();
     }, [photo?.Path, photo?.IsVideo]);
 
-    // Unmount cleanup: revoke any live blob URL and abort any in-flight fetch
-    useEffect(() => {
-        return () => {
-            abortControllerRef.current?.abort();
-            if (blobUrlRef.current) {
-                URL.revokeObjectURL(blobUrlRef.current);
-                blobUrlRef.current = null;
-            }
-        };
-    }, []); // empty deps = runs only on unmount
-
     useEffect(() => {
         if (!photo || photo.IsVideo) {
-            // Videos use src attribute directly — clear any previous blob
-            if (blobUrlRef.current) {
-                URL.revokeObjectURL(blobUrlRef.current);
-                blobUrlRef.current = null;
-            }
             setImageSrc('');
             return;
         }
 
-        // Abort any previous in-flight request before starting a new one
-        abortControllerRef.current?.abort();
-        const controller = new AbortController();
-        abortControllerRef.current = controller;
-
+        // Use direct URL like the Grid — avoids cross-origin fetch issues in WKWebView
         const mediaUrl = `http://localhost:34342/wails-media?path=${encodeURIComponent(photo.Path)}`;
-
-        fetch(mediaUrl, { signal: controller.signal })
-            .then(res => {
-                if (!res.ok) throw new Error(`HTTP ${res.status}`);
-                return res.blob();
-            })
-            .then(blob => {
-                if (controller.signal.aborted) return; // navigated away during fetch
-                const newUrl = URL.createObjectURL(blob);
-                blobUrlRef.current = newUrl; // assign before setImageSrc so unmount cleanup can see it
-                setImageSrc(newUrl);
-            })
-            .catch(err => {
-                if (err.name === 'AbortError') return; // expected — user navigated away
-                console.error('Failed to load image:', err);
-            });
+        setImageSrc(mediaUrl);
     }, [photo?.Path, photo?.IsVideo]);
 
     if (!photo) {
@@ -180,14 +143,6 @@ export function Viewer({ photo, onTrimChange }: ViewerProps) {
                         src={imageSrc}
                         alt={filename}
                         className="viewer-image"
-                        onLoad={() => {
-                            // Revoke the PREVIOUS blob URL only after the new image is fully painted.
-                            // Never revoke here if blobUrlRef.current === imageSrc (same image).
-                            if (blobUrlRef.current && blobUrlRef.current !== imageSrc) {
-                                URL.revokeObjectURL(blobUrlRef.current);
-                            }
-                            blobUrlRef.current = imageSrc;
-                        }}
                     />
                 )}
             </div>


### PR DESCRIPTION
## Summary
- Replaces `fetch()→blob→objectURL` with direct `<img src>` URL for the viewer
- Matches the pattern already used by Grid thumbnails and `<video>` elements
- Removes 47 lines of AbortController/blob management code

## Root Cause
The `fetch()` call to `http://localhost:34342` fails in WKWebView production builds due to cross-origin restrictions. The `<img src>` and `<video src>` elements with the same URL work fine (proven by Grid and video playback).

## Test plan
- [ ] Open folder, click photo — viewer shows full-size image
- [ ] Navigate between photos rapidly — no memory leaks or stale images
- [ ] Video viewer still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)