### PR TITLE
chore: remove redundant homebrew-cullsnap from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,16 +149,3 @@ jobs:
           git add Casks/cullsnap.rb
           git diff --cached --quiet || git commit -m "Update CullSnap cask to ${GITHUB_REF_NAME}"
           git push
-
-      - name: Push to homebrew-cullsnap
-        env:
-          TAP_TOKEN: ${{ secrets.CULLSNAP_HOMEBREW_TAP_TOKEN }}
-        run: |
-          git clone https://x-access-token:${TAP_TOKEN}@github.com/Abhishekmitra-slg/homebrew-cullsnap.git /tmp/homebrew-cullsnap
-          cp cullsnap.rb /tmp/homebrew-cullsnap/Casks/cullsnap.rb
-          cd /tmp/homebrew-cullsnap
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Casks/cullsnap.rb
-          git diff --cached --quiet || git commit -m "Update CullSnap cask to ${GITHUB_REF_NAME}"
-          git push


### PR DESCRIPTION
Only one Homebrew tap needed (homebrew-tap). Remove the push to homebrew-cullsnap.