### PR TITLE
Add tabbed Help modal and keyboard shortcuts

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { Grid } from './components/Grid';
 import { Viewer } from './components/Viewer';
 import { SettingsModal } from './components/SettingsModal';
 import { AboutModal } from './components/AboutModal';
+import { HelpModal } from './components/HelpModal';
 import { SelectDirectory, ScanDirectory, ScanAndDeduplicate, CancelDeduplicate, GetExportedStatus, GetSelections, ToggleSelection, ExportPhotos, SetPhotoRating, GetRatingsForDirectory, CheckDedupStatus, PreloadThumbnails } from '../wailsjs/go/app/App';
 import { model as appModel } from '../wailsjs/go/models';
 
@@ -37,6 +38,7 @@ function App() {
     const [thumbProgress, setThumbProgress] = useState<{current: number, total: number} | null>(null);
     const [settingsOpen, setSettingsOpen] = useState(false);
     const [aboutOpen, setAboutOpen] = useState(false);
+    const [helpOpen, setHelpOpen] = useState(false);
 
     useEffect(() => {
         EventsOn('sys-metrics', (data: any) => {
@@ -131,11 +133,21 @@ function App() {
                             ?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
                     }
                 }
+            } else if (e.key >= '1' && e.key <= '5') {
+                if (activePhotoPath) {
+                    const star = parseInt(e.key, 10);
+                    const current = ratings[activePhotoPath] || 0;
+                    const newRating = current === star ? 0 : star;
+                    setRatings(prev => ({ ...prev, [activePhotoPath]: newRating }));
+                    SetPhotoRating(activePhotoPath, newRating).catch(err =>
+                        console.error('Failed to save rating:', err)
+                    );
+                }
             }
         };
         window.addEventListener('keydown', handleKeyDown);
         return () => window.removeEventListener('keydown', handleKeyDown);
-    }, [activePhotoPath, selectedPaths, photos, currentDir, setActivePhotoDebounced]);
+    }, [activePhotoPath, selectedPaths, photos, currentDir, ratings, setActivePhotoDebounced]);
 
     const handleOpenFolder = async () => {
         try {
@@ -375,6 +387,7 @@ function App() {
                 duplicateCount={duplicateGroups.reduce((acc, g) => acc + g.length, 0)}
                 onOpenSettings={() => setSettingsOpen(true)}
                 onOpenAbout={() => setAboutOpen(true)}
+                onOpenHelp={() => setHelpOpen(true)}
             />
 
             <div className="main-content" style={{ position: 'relative' }}>
@@ -420,6 +433,7 @@ function App() {
 
             {settingsOpen && <SettingsModal onClose={() => setSettingsOpen(false)} />}
             {aboutOpen && <AboutModal onClose={() => setAboutOpen(false)} />}
+            {helpOpen && <HelpModal onClose={() => setHelpOpen(false)} />}
         </div>
     );
 }

--- a/frontend/src/components/HelpModal.tsx
+++ b/frontend/src/components/HelpModal.tsx
@@ -1,0 +1,249 @@
+import { useState } from 'react';
+import { X } from 'lucide-react';
+
+interface HelpModalProps {
+    onClose: () => void;
+}
+
+const tabs = ['Getting Started', 'Shortcuts', 'Features', 'Exporting'] as const;
+type Tab = (typeof tabs)[number];
+
+function Kbd({ children }: { children: React.ReactNode }) {
+    return (
+        <kbd
+            style={{
+                background: 'var(--bg-surface)',
+                padding: '2px 8px',
+                borderRadius: 4,
+                border: '1px solid var(--border-color)',
+                fontSize: '0.7rem',
+                fontFamily: 'inherit',
+                fontWeight: 600,
+                minWidth: 24,
+                display: 'inline-block',
+                textAlign: 'center',
+            }}
+        >
+            {children}
+        </kbd>
+    );
+}
+
+function ShortcutRow({ keys, description }: { keys: React.ReactNode; description: string }) {
+    return (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '6px 0' }}>
+            <div style={{ minWidth: 100, display: 'flex', gap: 4, flexShrink: 0 }}>{keys}</div>
+            <span style={{ color: 'var(--text-secondary)', fontSize: '0.8rem' }}>{description}</span>
+        </div>
+    );
+}
+
+function GettingStartedTab() {
+    const steps = [
+        {
+            title: '1. Open a folder',
+            text: 'Click Open Folder in the sidebar or drag a folder into the window to load your photos and videos.',
+        },
+        {
+            title: '2. Browse & review',
+            text: 'Use arrow keys or click thumbnails to navigate. The viewer shows the full-resolution image with EXIF details.',
+        },
+        {
+            title: '3. Select your keepers',
+            text: 'Press S or click the checkmark on thumbnails to select photos you want to keep. Use star ratings (1\u20135) to rank quality.',
+        },
+        {
+            title: '4. Find duplicates',
+            text: 'Click Find Duplicates to automatically detect near-identical photos using perceptual hashing. Duplicates are grouped and highlighted in the grid.',
+        },
+        {
+            title: '5. Export',
+            text: 'Click Export to copy your selected photos to a new folder. Video trim points are preserved during export.',
+        },
+    ];
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            <p style={{ color: 'var(--text-secondary)', fontSize: '0.8rem', margin: 0, lineHeight: 1.6 }}>
+                CullSnap helps you quickly sort through large photo collections. Here's the typical workflow:
+            </p>
+            {steps.map((step) => (
+                <div key={step.title}>
+                    <div style={{ fontWeight: 600, fontSize: '0.825rem', color: 'var(--text-primary)', marginBottom: 4 }}>
+                        {step.title}
+                    </div>
+                    <div style={{ fontSize: '0.78rem', color: 'var(--text-secondary)', lineHeight: 1.5 }}>
+                        {step.text}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+function ShortcutsTab() {
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            <div>
+                <h4 style={{ margin: '0 0 8px', fontSize: '0.78rem', color: 'var(--accent)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                    Navigation
+                </h4>
+                <ShortcutRow
+                    keys={<><Kbd>&larr;</Kbd><Kbd>&uarr;</Kbd></>}
+                    description="Previous photo"
+                />
+                <ShortcutRow
+                    keys={<><Kbd>&rarr;</Kbd><Kbd>&darr;</Kbd></>}
+                    description="Next photo"
+                />
+            </div>
+            <div>
+                <h4 style={{ margin: '0 0 8px', fontSize: '0.78rem', color: 'var(--accent)', textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+                    Selection & Rating
+                </h4>
+                <ShortcutRow
+                    keys={<Kbd>S</Kbd>}
+                    description="Toggle selection on active photo"
+                />
+                <ShortcutRow
+                    keys={<><Kbd>1</Kbd> <span style={{ color: 'var(--text-muted)', fontSize: '0.7rem' }}>to</span> <Kbd>5</Kbd></>}
+                    description="Set star rating (press again to clear)"
+                />
+            </div>
+        </div>
+    );
+}
+
+function FeaturesTab() {
+    const features = [
+        {
+            title: 'Smart Deduplication',
+            text: 'Uses perceptual hashing (dHash) to find visually similar photos, even if they differ in resolution or compression. Photos are scored by quality to help you pick the best version.',
+        },
+        {
+            title: 'Star Ratings',
+            text: 'Rate photos from 1 to 5 stars using keyboard shortcuts or by clicking stars on thumbnails. Ratings persist across sessions.',
+        },
+        {
+            title: 'Video Support',
+            text: 'Browse and preview video files alongside photos. Set trim points in the viewer to export only the portion you need. Requires FFmpeg.',
+        },
+        {
+            title: 'Themes',
+            text: 'Toggle between dark and light mode using the sun/moon icon in the sidebar header.',
+        },
+        {
+            title: 'System Metrics',
+            text: 'The status bar shows real-time CPU, RAM, disk I/O, and network usage so you can monitor performance during large scans.',
+        },
+    ];
+
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+            {features.map((f) => (
+                <div key={f.title}>
+                    <div style={{ fontWeight: 600, fontSize: '0.825rem', color: 'var(--text-primary)', marginBottom: 4 }}>
+                        {f.title}
+                    </div>
+                    <div style={{ fontSize: '0.78rem', color: 'var(--text-secondary)', lineHeight: 1.5 }}>
+                        {f.text}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+function ExportingTab() {
+    return (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            <p style={{ color: 'var(--text-secondary)', fontSize: '0.8rem', margin: 0, lineHeight: 1.6 }}>
+                Export copies your selected photos and videos to a new folder, keeping originals untouched.
+            </p>
+
+            <div>
+                <div style={{ fontWeight: 600, fontSize: '0.825rem', color: 'var(--text-primary)', marginBottom: 4 }}>
+                    How to export
+                </div>
+                <ol style={{ margin: 0, paddingLeft: 20, fontSize: '0.78rem', color: 'var(--text-secondary)', lineHeight: 1.8 }}>
+                    <li>Select the photos you want to keep (press <strong>S</strong> or click checkmarks)</li>
+                    <li>Click the <strong>Export</strong> button in the sidebar</li>
+                    <li>Choose a destination folder</li>
+                    <li>Name your export session (a default timestamp name is provided)</li>
+                </ol>
+            </div>
+
+            <div>
+                <div style={{ fontWeight: 600, fontSize: '0.825rem', color: 'var(--text-primary)', marginBottom: 4 }}>
+                    Video trimming
+                </div>
+                <div style={{ fontSize: '0.78rem', color: 'var(--text-secondary)', lineHeight: 1.5 }}>
+                    If you set trim points on a video in the viewer, the exported file will contain only the trimmed segment. This requires FFmpeg to be installed on your system.
+                </div>
+            </div>
+
+            <div>
+                <div style={{ fontWeight: 600, fontSize: '0.825rem', color: 'var(--text-primary)', marginBottom: 4 }}>
+                    Supported formats
+                </div>
+                <div style={{ fontSize: '0.78rem', color: 'var(--text-secondary)', lineHeight: 1.5 }}>
+                    Images: JPG, JPEG, PNG. Videos: MP4, MOV, AVI, MKV, WEBM (when FFmpeg is available).
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export function HelpModal({ onClose }: HelpModalProps) {
+    const [activeTab, setActiveTab] = useState<Tab>('Getting Started');
+
+    return (
+        <div className="settings-overlay" onClick={onClose}>
+            <div className="settings-modal glass-panel" onClick={e => e.stopPropagation()} style={{ maxWidth: 540 }}>
+                <div className="settings-header">
+                    <h2>Help</h2>
+                    <button className="btn icon-btn" onClick={onClose}><X size={16} /></button>
+                </div>
+
+                {/* Tab bar */}
+                <div
+                    style={{
+                        display: 'flex',
+                        gap: 2,
+                        borderBottom: '1px solid var(--border-color)',
+                        paddingBottom: 0,
+                        marginBottom: 4,
+                    }}
+                >
+                    {tabs.map((tab) => (
+                        <button
+                            key={tab}
+                            onClick={() => setActiveTab(tab)}
+                            style={{
+                                background: 'none',
+                                border: 'none',
+                                borderBottom: activeTab === tab ? '2px solid var(--accent)' : '2px solid transparent',
+                                padding: '8px 14px',
+                                fontSize: '0.75rem',
+                                fontWeight: activeTab === tab ? 600 : 400,
+                                color: activeTab === tab ? 'var(--text-primary)' : 'var(--text-secondary)',
+                                cursor: 'pointer',
+                                transition: 'color 0.15s, border-color 0.15s',
+                            }}
+                        >
+                            {tab}
+                        </button>
+                    ))}
+                </div>
+
+                {/* Tab content */}
+                <section className="settings-section" style={{ flex: 1, overflowY: 'auto' }}>
+                    {activeTab === 'Getting Started' && <GettingStartedTab />}
+                    {activeTab === 'Shortcuts' && <ShortcutsTab />}
+                    {activeTab === 'Features' && <FeaturesTab />}
+                    {activeTab === 'Exporting' && <ExportingTab />}
+                </section>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { FolderOpen, Download, HelpCircle, FileText, Clock, Layers, X, Sun, Moon, Settings, Info } from 'lucide-react';
+import { FolderOpen, Download, HelpCircle, FileText, Clock, Layers, Sun, Moon, Settings, Info } from 'lucide-react';
 import { model } from '../../wailsjs/go/models';
 import { GetRecentFolders, SelectExportDirectory, ExportPhotos, OpenLog } from '../../wailsjs/go/app/App';
 
@@ -20,6 +20,7 @@ interface SidebarProps {
     duplicateCount: number;
     onOpenSettings: () => void;
     onOpenAbout: () => void;
+    onOpenHelp: () => void;
 }
 
 export function Sidebar({
@@ -38,11 +39,11 @@ export function Sidebar({
     dedupCompleted,
     duplicateCount,
     onOpenSettings,
-    onOpenAbout
+    onOpenAbout,
+    onOpenHelp
 }: SidebarProps) {
     const [recents, setRecents] = useState<string[]>([]);
     const [isExporting, setIsExporting] = useState(false);
-    const [showHelp, setShowHelp] = useState(false);
     const [exportDialog, setExportDialog] = useState<{ destDir: string; folderName: string } | null>(null);
 
     useEffect(() => {
@@ -190,7 +191,7 @@ export function Sidebar({
                     <button className="btn w-full justify-center" onClick={OpenLog} title="Open Logs">
                         <FileText size={14} />
                     </button>
-                    <button className="btn w-full justify-center" onClick={() => setShowHelp(true)} title="Help">
+                    <button className="btn w-full justify-center" onClick={onOpenHelp} title="Help">
                         <HelpCircle size={14} />
                     </button>
                     <button className="btn w-full justify-center" onClick={onOpenAbout} title="About">
@@ -224,37 +225,6 @@ export function Sidebar({
                 </div>
             )}
 
-            {/* Help Modal */}
-            {showHelp && (
-                <div className="modal-overlay" onClick={() => setShowHelp(false)}>
-                    <div className="modal-content" onClick={e => e.stopPropagation()}>
-                        <div className="flex justify-between items-center mb-3">
-                            <h2 style={{ margin: 0 }}>Help & Shortcuts</h2>
-                            <button className="btn" onClick={() => setShowHelp(false)} style={{ padding: '4px 8px' }}>
-                                <X size={16} />
-                            </button>
-                        </div>
-
-                        <div className="text-small" style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem', lineHeight: '1.6' }}>
-                            <section>
-                                <h3 style={{ color: 'var(--accent)', fontSize: '0.8125rem', marginBottom: 6 }}>Getting Started</h3>
-                                <p>CullSnap is a high-performance photo culling tool. Click <strong>Open Folder</strong> to load a directory of images.</p>
-                            </section>
-                            <section>
-                                <h3 style={{ color: 'var(--accent)', fontSize: '0.8125rem', marginBottom: 6 }}>Keyboard Shortcuts</h3>
-                                <ul style={{ listStyle: 'none', padding: 0, display: 'flex', flexDirection: 'column', gap: 6 }}>
-                                    <li><kbd style={{ background: 'var(--bg-panel)', padding: '2px 6px', borderRadius: 4, border: '1px solid var(--border-color)', fontSize: '0.7rem' }}>S</kbd> — Toggle selection</li>
-                                    <li><kbd style={{ background: 'var(--bg-panel)', padding: '2px 6px', borderRadius: 4, border: '1px solid var(--border-color)', fontSize: '0.7rem' }}>← →</kbd> — Navigate photos</li>
-                                </ul>
-                            </section>
-                            <section>
-                                <h3 style={{ color: 'var(--accent)', fontSize: '0.8125rem', marginBottom: 6 }}>Exporting</h3>
-                                <p>Select photos with <strong>S</strong>, then click <strong>Export</strong>.</p>
-                            </section>
-                        </div>
-                    </div>
-                </div>
-            )}
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- New `HelpModal` component with 4 tabbed sections: Getting Started, Keyboard Shortcuts, Features, and Exporting
- Added keyboard shortcuts `1-5` for setting star ratings on the active photo (press again to clear)
- Replaced minimal inline help in Sidebar with the new comprehensive modal
- No backend changes, no new dependencies

Closes #15

## Test plan
- [ ] Open Help modal from sidebar — verify all 4 tabs render correctly
- [ ] Test keyboard shortcuts: arrow keys (navigate), S (select), 1-5 (star rating toggle)
- [ ] Verify Escape key and backdrop click close the Help modal
- [ ] Confirm dark and light themes render the modal correctly
- [ ] Run `go test ./...` — all tests pass, coverage above 35%