### PR TITLE
ui: add tagline to About modal

### DIFF
--- a/frontend/src/components/AboutModal.tsx
+++ b/frontend/src/components/AboutModal.tsx
@@ -103,6 +103,7 @@ export function AboutModal({ onClose }: AboutModalProps) {
                 <section className="settings-section">
                     <div style={{ textAlign: 'center', marginBottom: 16 }}>
                         <h3 style={{ fontSize: '1.25rem', margin: '0 0 4px' }}>CullSnap</h3>
+                        <p style={{ fontSize: '0.75rem', color: 'var(--text-secondary)', margin: '0 0 4px', fontStyle: 'italic' }}>Fast photo culling, simplified.</p>
                         <span style={{ fontSize: '0.85rem', color: 'var(--text-secondary)' }}>
                             {about.version}
                         </span>


### PR DESCRIPTION
## Summary
- Adds "Fast photo culling, simplified." tagline under the app name in the About modal
- Cosmetic change to test auto-update flow with v2.3.1

## Test plan
- [x] Visual-only change, no logic affected