### PR TITLE
chore: add Google site verification and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ Thumbs.db
 
 # Claude Code
 .claude/
+memory/
+
+# Screenshots / local image artifacts
+cullsnap-*.png
 
 # Planning docs, specs, design docs (local working documents only)
 .superpowers/

--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -1,1 +1,2 @@
 <link rel="icon" type="image/png" href="{{ '/favicon.ico' | relative_url }}">
+<meta name="google-site-verification" content="NGt8pml6X8oRcVcjBijR9agh-j0cDDPsybZPKcToXs4" />


### PR DESCRIPTION
## Summary
- Add Google Search Console verification meta tag to GitHub Pages site for domain ownership verification
- Update `.gitignore` to exclude local screenshot artifacts (`cullsnap-*.png`) and Claude memory directory (`memory/`)

## Test plan
- [ ] CI passes
- [ ] After merge, verify Google site verification meta tag appears in page source at cullsnap site
- [ ] Verify `.gitignore` excludes intended files