### PR TITLE
fix(icloud): add Apple Events permission and user-friendly TCC error

### DIFF
--- a/build/darwin/Info.dev.plist
+++ b/build/darwin/Info.dev.plist
@@ -23,6 +23,8 @@
         <string>true</string>
         <key>NSHumanReadableCopyright</key>
         <string>{{.Info.Copyright}}</string>
+        <key>NSAppleEventsUsageDescription</key>
+        <string>CullSnap needs to communicate with Photos to browse and export your iCloud photo albums.</string>
         {{if .Info.FileAssociations}}
         <key>CFBundleDocumentTypes</key>
         <array>

--- a/build/darwin/Info.plist
+++ b/build/darwin/Info.plist
@@ -23,6 +23,8 @@
         <string>true</string>
         <key>NSHumanReadableCopyright</key>
         <string>{{.Info.Copyright}}</string>
+        <key>NSAppleEventsUsageDescription</key>
+        <string>CullSnap needs to communicate with Photos to browse and export your iCloud photo albums.</string>
         {{if .Info.FileAssociations}}
         <key>CFBundleDocumentTypes</key>
         <array>

--- a/internal/cloudsource/providers/icloud/provider.go
+++ b/internal/cloudsource/providers/icloud/provider.go
@@ -164,6 +164,13 @@ func runOsascript(ctx context.Context, script string) (string, error) {
 		if errMsg == "" {
 			errMsg = err.Error()
 		}
+		logger.Log.Debug("icloud: osascript failed", "stderr", errMsg)
+
+		// macOS TCC error -1743: app lacks Automation permission for Photos.app
+		if strings.Contains(errMsg, "-1743") || strings.Contains(errMsg, "Not authorized") {
+			return "", fmt.Errorf("CullSnap needs Automation permission to access Photos. " +
+				"Open System Settings \u2192 Privacy & Security \u2192 Automation and enable Photos for CullSnap, then try again")
+		}
 		return "", fmt.Errorf("osascript: %s", errMsg)
 	}
 


### PR DESCRIPTION
## Summary
- Add `NSAppleEventsUsageDescription` to both `Info.plist` and `Info.dev.plist` so macOS shows the proper Automation permission dialog when CullSnap accesses Photos.app
- Detect macOS TCC error `-1743` ("Not authorized to send Apple events") and display a clear, actionable message guiding users to System Settings instead of raw osascript stderr
- Before: `Failed to load albums: icloud: failed to list albums: osascript: 49:269: execution error: Not authorized to send Apple events to Photos. (-1743)`
- After: `Failed to load albums: icloud: failed to list albums: CullSnap needs Automation permission to access Photos. Open System Settings → Privacy & Security → Automation and enable Photos for CullSnap, then try again`

## Test plan
- [ ] CI passes
- [ ] Build app, open Cloud Albums, click Browse on iCloud Photos
- [ ] If permission not granted, verify user-friendly error message appears
- [ ] If permission granted, verify albums load correctly
- [ ] Reset Automation permission via `tccutil reset AppleEvents com.wails.cullsnap` and verify permission dialog appears on next access