### PR TITLE
fix(build): ad-hoc sign macOS app bundle for TCC permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,13 @@ jobs:
             wails build -platform ${{ matrix.platform }} -clean -m -ldflags "$LDFLAGS"
           fi
 
+      - name: Ad-hoc sign macOS app bundle
+        if: matrix.os == 'macos-latest'
+        run: |
+          codesign --force --deep --sign - build/bin/CullSnap.app
+          echo "Verifying signature..."
+          codesign -dv build/bin/CullSnap.app 2>&1
+
       - name: Compress macOS Binary
         if: matrix.os == 'macos-latest'
         run: |

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ lint:
 
 build: lint
 	go run github.com/wailsapp/wails/v2/cmd/wails@latest build -ldflags "-X main.version=$(VERSION)"
+ifeq ($(shell uname),Darwin)
+	@echo "Ad-hoc signing macOS app bundle..."
+	codesign --force --deep --sign - build/bin/CullSnap.app
+endif
 
 package:
 	./scripts/package.sh


### PR DESCRIPTION
## Summary
- The Go linker's minimal signature has `Identifier=a.out` and `Info.plist=not bound`, preventing macOS TCC from identifying CullSnap for Automation permissions
- Add `codesign --force --deep --sign -` step in release workflow after Wails build, producing a proper ad-hoc signature with correct bundle identifier and bound Info.plist
- Add same codesign step to Makefile for local builds on macOS
- Combined with v2.6.6's `NSAppleEventsUsageDescription` and TCC error detection, this completes the iCloud Photos fix

## Root cause chain
1. User clicks "Browse" on iCloud Photos → osascript sends Apple Events to Photos.app
2. macOS TCC checks which app is responsible → finds `Identifier=a.out` (linker default)
3. TCC can't match this to a real app → silently denies with error -1743
4. CullSnap never appears in System Settings > Automation

## After this fix
1. App is properly signed with `Identifier=com.wails.CullSnap` and bound Info.plist
2. First osascript call triggers macOS TCC dialog: "CullSnap wants to access Photos"
3. User grants permission → CullSnap appears in Automation settings
4. Albums load successfully

## Test plan
- [ ] CI passes
- [ ] Build app locally with `make build`, verify `codesign -dv build/bin/CullSnap.app` shows correct identifier
- [ ] After release, install app, open Cloud Albums, click Browse on iCloud Photos
- [ ] Verify macOS shows Automation permission dialog for CullSnap
- [ ] After granting, verify CullSnap appears in System Settings > Automation
- [ ] Verify albums load correctly