### PR TITLE
fix(build): self-heal bundle signature after auto-update

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -92,6 +92,10 @@ func NewApp(store *storage.SQLiteStore) *App {
 func (a *App) Startup(ctx context.Context) {
 	a.ctx = ctx
 
+	// Repair bundle signature if the auto-updater replaced the binary
+	// without re-signing. Must run before any TCC-gated operations.
+	ensureBundleSigned()
+
 	home, _ := os.UserHomeDir()
 	ffmpegPath := filepath.Join(home, ".cullsnap", "bin", "ffmpeg")
 	if stdruntime.GOOS == "windows" {

--- a/internal/app/codesign_darwin.go
+++ b/internal/app/codesign_darwin.go
@@ -1,0 +1,90 @@
+//go:build darwin
+
+package app
+
+import (
+	"cullsnap/internal/logger"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ensureBundleSigned verifies the app bundle signature and repairs it if needed.
+// The auto-updater replaces the binary without re-signing the bundle, which
+// breaks TCC attribution (macOS can't identify the app for Automation
+// permissions). This function detects that state and re-signs the bundle.
+func ensureBundleSigned() {
+	bundlePath := findAppBundle()
+	if bundlePath == "" {
+		logger.Log.Debug("codesign: not running from an app bundle, skipping")
+		return
+	}
+
+	plistPath := filepath.Join(bundlePath, "Contents", "Info.plist")
+	ensureAppleEventsUsageDescription(plistPath)
+
+	if err := exec.Command("codesign", "--verify", "--deep", "--strict", bundlePath).Run(); err == nil {
+		logger.Log.Debug("codesign: bundle signature is valid")
+		return
+	}
+
+	logger.Log.Info("codesign: bundle signature is invalid, re-signing", "bundle", bundlePath)
+
+	out, err := exec.Command("codesign", "--force", "--deep", "--sign", "-", bundlePath).CombinedOutput()
+	if err != nil {
+		logger.Log.Warn("codesign: failed to re-sign bundle", "error", err, "output", string(out))
+		return
+	}
+
+	logger.Log.Info("codesign: bundle re-signed successfully")
+}
+
+// ensureAppleEventsUsageDescription adds NSAppleEventsUsageDescription to
+// Info.plist if missing. This key is required for macOS to show the Automation
+// permission dialog when the app sends Apple Events to Photos.app.
+func ensureAppleEventsUsageDescription(plistPath string) {
+	data, err := os.ReadFile(plistPath)
+	if err != nil {
+		logger.Log.Debug("codesign: could not read Info.plist", "error", err)
+		return
+	}
+
+	if strings.Contains(string(data), "NSAppleEventsUsageDescription") {
+		return
+	}
+
+	logger.Log.Info("codesign: adding NSAppleEventsUsageDescription to Info.plist")
+
+	description := "CullSnap needs to communicate with Photos to browse and export your iCloud photo albums."
+	out, err := exec.Command(
+		"/usr/libexec/PlistBuddy",
+		"-c", "Add :NSAppleEventsUsageDescription string "+description,
+		plistPath,
+	).CombinedOutput()
+	if err != nil {
+		logger.Log.Warn("codesign: failed to update Info.plist", "error", err, "output", string(out))
+	}
+}
+
+// findAppBundle locates the .app bundle path from the running executable.
+func findAppBundle() string {
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		return ""
+	}
+
+	// Walk up from .../CullSnap.app/Contents/MacOS/CullSnap
+	dir := exe
+	for range 4 {
+		dir = filepath.Dir(dir)
+		if strings.HasSuffix(dir, ".app") {
+			return dir
+		}
+	}
+	return ""
+}

--- a/internal/app/codesign_stub.go
+++ b/internal/app/codesign_stub.go
@@ -1,0 +1,5 @@
+//go:build !darwin
+
+package app
+
+func ensureBundleSigned() {}


### PR DESCRIPTION
## Summary
- The auto-updater replaces only the binary (`CullSnap-darwin-universal`), not the full `.app` bundle. This leaves the code signature invalid and Info.plist unchanged from the original install
- Add startup self-healing (`ensureBundleSigned()`) that runs before any TCC-gated operations:
  1. Checks if `NSAppleEventsUsageDescription` exists in Info.plist, adds it if missing
  2. Verifies bundle signature with `codesign --verify --deep --strict`
  3. If invalid, re-signs with `codesign --force --deep --sign -`
- Non-darwin platforms get a no-op stub

## Why the CI codesign fix wasn't enough
The v2.6.7 release workflow properly signs the `.app` in CI. But users who auto-update get only a new binary — the `.app` shell (Info.plist, signature) stays from the original install. This self-healing mechanism fixes the bundle on first launch after any auto-update.

## Test plan
- [ ] CI passes
- [ ] After release, auto-update triggers and installs new binary
- [ ] On next launch, app logs show "codesign: bundle signature is invalid, re-signing"
- [ ] Verify `codesign -dv /Applications/CullSnap.app` shows `Info.plist entries=13` and `Sealed Resources`
- [ ] Reset TCC: `tccutil reset AppleEvents com.wails.CullSnap`
- [ ] Open Cloud Albums > Browse iCloud Photos — macOS shows Automation permission dialog
- [ ] CullSnap appears in System Settings > Automation