### PR TITLE
fix(docs): add privacy policy link to homepage for Google OAuth verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,6 +232,14 @@ jobs:
             | sed 's/^## ✨ /## /; s/^## 🏗️ /## /; s/^## 🛠️ /## /; s/^## 🎮 /## /; s/^## 📷 /## /; s/^## 📁 /## /; s/^## 🔒 /## /; s/^## 🤝 /## /; s/^## 📄 /## /; s/^## ⚖️ /## /' \
             | sed 's/^### 🍎 /### /' \
             >> docs/index.md
+          cat >> docs/index.md << 'LEGAL'
+
+---
+
+<div class="legal-footer">
+  <a href="privacy">Privacy Policy</a> · <a href="terms">Terms of Service</a>
+</div>
+LEGAL
 
       - name: Create pull request
         env:

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -79,3 +79,20 @@ footer {
   font-size: 0.85em;
   opacity: 0.85;
 }
+
+/* Legal footer — privacy policy and terms links */
+.legal-footer {
+  text-align: center;
+  padding: 1.5em 0 0.5em;
+  font-size: 0.9em;
+  color: #666;
+}
+
+.legal-footer a {
+  color: #4183c4;
+  text-decoration: none;
+}
+
+.legal-footer a:hover {
+  text-decoration: underline;
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -193,3 +193,9 @@ CullSnap is dual-licensed:
 ## Code of Conduct
 
 This project follows the [Contributor Covenant v2.1](CODE_OF_CONDUCT.md). Please read it before participating.
+
+---
+
+<div class="legal-footer">
+  <a href="privacy">Privacy Policy</a> · <a href="terms">Terms of Service</a>
+</div>


### PR DESCRIPTION
## Summary
- Add visible Privacy Policy and Terms of Service links to the GitHub Pages homepage footer
- Add CSS styling for the legal footer
- Update release workflow to preserve the footer on future README-to-index syncs

## Context
Google OAuth verification requires a visible privacy policy link on the app homepage. The privacy policy page already exists at `/privacy` but was not linked from the homepage.

## Test plan
- [ ] Verify GitHub Pages deploys with the footer visible at https://abhishekmitra-slg.github.io/CullSnap/
- [ ] Verify Privacy Policy link resolves to https://abhishekmitra-slg.github.io/CullSnap/privacy
- [ ] Verify Terms of Service link resolves to https://abhishekmitra-slg.github.io/CullSnap/terms
- [ ] Resubmit homepage for Google OAuth verification review