### PR TITLE
fix(ci): repair release.yml YAML syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,14 +232,7 @@ jobs:
             | sed 's/^## ✨ /## /; s/^## 🏗️ /## /; s/^## 🛠️ /## /; s/^## 🎮 /## /; s/^## 📷 /## /; s/^## 📁 /## /; s/^## 🔒 /## /; s/^## 🤝 /## /; s/^## 📄 /## /; s/^## ⚖️ /## /' \
             | sed 's/^### 🍎 /### /' \
             >> docs/index.md
-          cat >> docs/index.md << 'LEGAL'
-
----
-
-<div class="legal-footer">
-  <a href="privacy">Privacy Policy</a> · <a href="terms">Terms of Service</a>
-</div>
-LEGAL
+          printf '\n\n%s\n\n%s\n' '---' '<div class="legal-footer"><a href="privacy">Privacy Policy</a> · <a href="terms">Terms of Service</a></div>' >> docs/index.md
 
       - name: Create pull request
         env:


### PR DESCRIPTION
## Summary
- Fix YAML parsing error in release.yml caused by `---` in a heredoc at column 1
- YAML interprets `---` as a document separator, breaking the workflow file
- Replace heredoc with `printf` to avoid the issue

## Context
PR #49 added a legal footer heredoc that contained `---` (markdown horizontal rule) at column 1. This broke the release workflow for any push event.

## Test plan
- [ ] YAML validated locally with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`
- [ ] CI checks pass