### PR TITLE
fix: resolve SCRFD tensor collision causing false face detections

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,7 @@ import { DeviceImportModal } from './components/DeviceImportModal';
 import { UpdateToast } from './components/UpdateToast';
 import { WhatsNewModal } from './components/WhatsNewModal';
 import { AIProgressModal } from './components/AIProgressModal';
-import { SelectDirectory, ScanDirectory, ScanAndDeduplicate, CancelDeduplicate, GetExportedStatus, GetSelections, ToggleSelection, ExportPhotos, SetPhotoRating, GetRatingsForDirectory, CheckDedupStatus, PreloadThumbnailsForPhotos, GetAppConfig, ShouldShowWhatsNew, GetAIScoringStatus, GetPhotoAIScore, RunAIAnalysis } from '../wailsjs/go/app/App';
+import { SelectDirectory, ScanDirectory, ScanAndDeduplicate, CancelDeduplicate, GetExportedStatus, GetSelections, ToggleSelection, ExportPhotos, SetPhotoRating, GetRatingsForDirectory, CheckDedupStatus, PreloadThumbnailsForPhotos, GetAppConfig, ShouldShowWhatsNew, GetAIScoringStatus, GetPhotoAIScore, RunAIAnalysis, ClearAIData } from '../wailsjs/go/app/App';
 import { model as appModel, app as appTypes, storage } from '../wailsjs/go/models';
 import { EventsOn, EventsOff } from '../wailsjs/runtime/runtime';
 import AIPanel from './components/AIPanel';
@@ -729,6 +729,21 @@ function App() {
                 }}
                 aiPanelVisible={aiPanelVisible}
                 onToggleAIPanel={() => setAiPanelVisible(prev => !prev)}
+                hasAIScores={Object.keys(aiScores).length > 0}
+                onReanalyze={() => {
+                    if (!currentDir) return;
+                    setIsAnalyzing(true);
+                    setAiPanelVisible(true);
+                    setShowAIModal(true);
+                    setAiScores({});
+                    setAiClusters([]);
+                    ClearAIData(currentDir).then(() => {
+                        return RunAIAnalysis(currentDir);
+                    }).catch((err: unknown) => {
+                        console.error('[ai] re-analysis failed:', err);
+                        setIsAnalyzing(false);
+                    });
+                }}
             />
 
             <div

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -29,6 +29,8 @@ interface SidebarProps {
     onAnalyze?: () => void;
     aiPanelVisible?: boolean;
     onToggleAIPanel?: () => void;
+    hasAIScores?: boolean;
+    onReanalyze?: () => void;
 }
 
 export function Sidebar({
@@ -57,6 +59,8 @@ export function Sidebar({
     onAnalyze,
     aiPanelVisible,
     onToggleAIPanel,
+    hasAIScores,
+    onReanalyze,
 }: SidebarProps) {
     const [recents, setRecents] = useState<string[]>([]);
     const [isExporting, setIsExporting] = useState(false);
@@ -158,15 +162,37 @@ export function Sidebar({
                 )}
 
                 {aiEnabled && (
-                    <button
-                        className="btn w-full mt-2"
-                        onClick={onAnalyze}
-                        disabled={isAnalyzing || photosCount === 0 || !currentDir}
-                        title="Run AI face detection and quality scoring"
-                    >
-                        <Sparkles size={16} />
-                        {isAnalyzing ? 'Analyzing...' : 'Analyze with AI'}
-                    </button>
+                    <>
+                        <button
+                            className="btn w-full mt-2"
+                            onClick={onAnalyze}
+                            disabled={isAnalyzing || photosCount === 0 || !currentDir}
+                            title="Run AI face detection and quality scoring"
+                        >
+                            <Sparkles size={16} />
+                            {isAnalyzing ? 'Analyzing...' : 'Analyze with AI'}
+                        </button>
+                        {hasAIScores && !isAnalyzing && (
+                            <div style={{ textAlign: 'center', marginTop: 2 }}>
+                                <button
+                                    onClick={onReanalyze}
+                                    disabled={!currentDir}
+                                    style={{
+                                        background: 'none',
+                                        border: 'none',
+                                        color: 'var(--text-muted)',
+                                        fontSize: '0.65rem',
+                                        cursor: 'pointer',
+                                        textDecoration: 'underline',
+                                        padding: '2px 4px',
+                                    }}
+                                    title="Clear existing AI data and re-run analysis from scratch"
+                                >
+                                    Re-analyze from scratch
+                                </button>
+                            </div>
+                        )}
+                    </>
                 )}
             </div>
 

--- a/frontend/src/components/Viewer.tsx
+++ b/frontend/src/components/Viewer.tsx
@@ -37,7 +37,7 @@ const THUMB_WIDTH = 300;
 
 export function Viewer({ photo, onTrimChange, isSelected, faceDetections, aiPanelVisible, onFaceClick }: ViewerProps) {
     const [exif, setExif] = useState<PhotoEXIF | null>(null);
-    const [showFaceOverlay, setShowFaceOverlay] = useState(true);
+    const [showFaceOverlay, setShowFaceOverlay] = useState(false);
     const [hoveredFace, setHoveredFace] = useState<number | null>(null);
     const videoRef = useRef<HTMLVideoElement>(null);
     const imageRef = useRef<HTMLImageElement>(null);

--- a/frontend/wailsjs/go/app/App.d.ts
+++ b/frontend/wailsjs/go/app/App.d.ts
@@ -14,6 +14,8 @@ export function CancelAIAnalysis():Promise<void>;
 
 export function CancelDeduplicate():Promise<void>;
 
+export function ClearAIData(arg1:string):Promise<void>;
+
 export function CancelImport(arg1:string):Promise<void>;
 
 export function CancelMirror(arg1:string,arg2:string):Promise<void>;

--- a/frontend/wailsjs/go/app/App.js
+++ b/frontend/wailsjs/go/app/App.js
@@ -18,6 +18,10 @@ export function CancelDeduplicate() {
   return window['go']['app']['App']['CancelDeduplicate']();
 }
 
+export function ClearAIData(arg1) {
+  return window['go']['app']['App']['ClearAIData'](arg1);
+}
+
 export function CancelImport(arg1) {
   return window['go']['app']['App']['CancelImport'](arg1);
 }

--- a/internal/app/ai_methods.go
+++ b/internal/app/ai_methods.go
@@ -165,6 +165,17 @@ func (a *App) CancelAIAnalysis() error {
 	return nil
 }
 
+// ClearAIData removes all AI scores, face detections, and face clusters
+// for the given folder so the next RunAIAnalysis re-processes every photo.
+func (a *App) ClearAIData(folderPath string) error {
+	logger.Log.Info("app: clearing AI data", "folder", folderPath)
+	if err := a.store.DeleteAIDataForFolder(folderPath); err != nil {
+		logger.Log.Error("app: failed to clear AI data", "error", err)
+		return fmt.Errorf("clear AI data: %w", err)
+	}
+	return nil
+}
+
 // DownloadAIModels provisions ONNX Runtime and downloads all model files,
 // then initialises the plugins.
 func (a *App) DownloadAIModels() error {

--- a/internal/scoring/extra_coverage_test.go
+++ b/internal/scoring/extra_coverage_test.go
@@ -4,6 +4,7 @@ package scoring
 
 import (
 	"context"
+	"fmt"
 	"image"
 	"image/color"
 	"math"
@@ -136,6 +137,92 @@ func TestParseSCRFDGeneric_PicksLargestTensor(t *testing.T) {
 	result := parseSCRFDGeneric(tensors, 640, 480, 0.5)
 	if len(result) != 2 {
 		t.Errorf("parseSCRFDGeneric(largest tensor) = %d faces, want 2", len(result))
+	}
+}
+
+// TestParseSCRFDStridedOutputs_NameBasedMatching verifies that tensors are matched
+// by name to avoid cross-stride collisions where element counts are ambiguous
+// (e.g. stride-8 scores = 12800 elements = stride-16 boxes).
+func TestParseSCRFDStridedOutputs_NameBasedMatching(t *testing.T) {
+	// Simulate SCRFD 2.5G output tensors with realistic naming and sizes.
+	// Only populate stride-8 with a detectable face; other strides are zeros.
+	const inputSize = 640
+	numAnchors := 2
+
+	type strideSpec struct {
+		stride  int
+		numLocs int
+	}
+	strides := []strideSpec{
+		{8, (inputSize / 8) * (inputSize / 8) * numAnchors},    // 12800
+		{16, (inputSize / 16) * (inputSize / 16) * numAnchors}, // 3200
+		{32, (inputSize / 32) * (inputSize / 32) * numAnchors}, // 800
+	}
+
+	var tensors []scrfdTensor
+	for _, s := range strides {
+		scores := make([]float32, s.numLocs)
+		boxes := make([]float32, s.numLocs*4)
+
+		// Put a single high-confidence detection in stride 8 only.
+		if s.stride == 8 {
+			scores[0] = 0.95 // high confidence
+			// Distance-based bbox: [left, top, right, bottom] distances from anchor.
+			boxes[0] = 2.0 // left
+			boxes[1] = 2.0 // top
+			boxes[2] = 2.0 // right
+			boxes[3] = 2.0 // bottom
+		}
+
+		tensors = append(tensors,
+			scrfdTensor{
+				name:  fmt.Sprintf("score_%d", s.stride),
+				shape: []int64{1, int64(s.numLocs), 1},
+				data:  scores,
+			},
+			scrfdTensor{
+				name:  fmt.Sprintf("bbox_%d", s.stride),
+				shape: []int64{1, int64(s.numLocs), 4},
+				data:  boxes,
+			},
+		)
+	}
+
+	faces := parseSCRFDStridedOutputs(tensors, 300, 200, scrfdConfThresh)
+
+	// With correct name-based matching, only 1 face should be detected.
+	// The old size-only matching could produce thousands of false detections
+	// because box data (large floats) would be misread as confidence scores.
+	if len(faces) != 1 {
+		t.Errorf("parseSCRFDStridedOutputs() detected %d faces, want 1", len(faces))
+	}
+	if len(faces) > 0 && faces[0].Confidence < 0.9 {
+		t.Errorf("face confidence = %f, want >= 0.9", faces[0].Confidence)
+	}
+}
+
+// TestParseSCRFDStridedOutputs_FallbackSizeBased verifies that unnamed tensors
+// still work via the size-based fallback with used-tensor tracking.
+func TestParseSCRFDStridedOutputs_FallbackSizeBased(t *testing.T) {
+	// Use unnamed tensors (no stride info in name) for stride 32 only (simplest).
+	numLocs := (640 / 32) * (640 / 32) * 2 // 800
+
+	scores := make([]float32, numLocs)
+	boxes := make([]float32, numLocs*4)
+	scores[0] = 0.85
+	boxes[0] = 1.0
+	boxes[1] = 1.0
+	boxes[2] = 1.0
+	boxes[3] = 1.0
+
+	tensors := []scrfdTensor{
+		{name: "output_a", shape: []int64{1, int64(numLocs), 1}, data: scores},
+		{name: "output_b", shape: []int64{1, int64(numLocs), 4}, data: boxes},
+	}
+
+	faces := parseSCRFDStridedOutputs(tensors, 300, 200, scrfdConfThresh)
+	if len(faces) != 1 {
+		t.Errorf("parseSCRFDStridedOutputs(unnamed) detected %d faces, want 1", len(faces))
 	}
 }
 

--- a/internal/scoring/face_detector.go
+++ b/internal/scoring/face_detector.go
@@ -322,7 +322,7 @@ func parseSCRFDStridedOutputs(tensors []scrfdTensor, imgW, imgH int, confThresh 
 		var scoreData []float32
 		var boxData []float32
 		var kpsData []float32
-		var scoreIdx, boxIdx, kpsIdx int = -1, -1, -1
+		scoreIdx, boxIdx, kpsIdx := -1, -1, -1
 
 		strideStr := fmt.Sprintf("%d", stride)
 

--- a/internal/scoring/face_detector.go
+++ b/internal/scoring/face_detector.go
@@ -9,6 +9,7 @@ import (
 	"image"
 	"math"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/shota3506/onnxruntime-purego/onnxruntime"
@@ -299,9 +300,16 @@ func parseSCRFDOutputs(outputs map[string]*onnxruntime.Value, imgW, imgH int, co
 
 // parseSCRFDStridedOutputs handles the canonical SCRFD output format where
 // separate score and box tensors are emitted for each of the 3 strides.
+//
+// Tensors are matched by name first (e.g. "score_8", "bbox_16") to avoid
+// ambiguity — different strides can have identical element counts
+// (stride 8 scores == stride 16 boxes == 12800 elements).
 func parseSCRFDStridedOutputs(tensors []scrfdTensor, imgW, imgH int, confThresh float32) []FaceRegion {
 	strides := []int{8, 16, 32}
 	numAnchors := 2 // SCRFD 2.5G uses 2 anchors per location
+
+	// Track which tensors have been claimed to prevent cross-stride reuse.
+	used := make(map[int]bool)
 
 	var faces []FaceRegion
 	found := false
@@ -311,29 +319,81 @@ func parseSCRFDStridedOutputs(tensors []scrfdTensor, imgW, imgH int, confThresh 
 		featW := scrfdInputSize / stride
 		numLocs := featH * featW * numAnchors
 
-		// Find matching score tensor (shape [1, numLocs, 1] or [1, numLocs]).
 		var scoreData []float32
 		var boxData []float32
 		var kpsData []float32
+		var scoreIdx, boxIdx, kpsIdx int = -1, -1, -1
 
-		for _, t := range tensors {
-			n := tensorNumElements(t.shape)
-			if n == 0 {
+		strideStr := fmt.Sprintf("%d", stride)
+
+		// Pass 1: match by tensor name (e.g. "score_8", "bbox_32").
+		for i, t := range tensors {
+			if used[i] {
 				continue
 			}
+			nameLower := strings.ToLower(t.name)
+			if !strings.Contains(nameLower, strideStr) {
+				continue
+			}
+			n := tensorNumElements(t.shape)
 			switch {
-			case n == numLocs && matchesScoreShape(t.shape, numLocs):
+			case strings.Contains(nameLower, "score") && n == numLocs:
 				scoreData = t.data
-			case n == numLocs*4 && matchesBoxShape(t.shape, numLocs):
+				scoreIdx = i
+			case (strings.Contains(nameLower, "bbox") || strings.Contains(nameLower, "box")) && n == numLocs*4:
 				boxData = t.data
-			case n == numLocs*10 && matchesKpsShape(t.shape, numLocs):
+				boxIdx = i
+			case strings.Contains(nameLower, "kps") && n == numLocs*10:
 				kpsData = t.data
+				kpsIdx = i
+			}
+		}
+
+		// Pass 2: fall back to size-based matching only for tensors not yet claimed.
+		if scoreData == nil || boxData == nil {
+			for i, t := range tensors {
+				if used[i] {
+					continue
+				}
+				n := tensorNumElements(t.shape)
+				if n == 0 {
+					continue
+				}
+				switch {
+				case scoreData == nil && n == numLocs && matchesScoreShape(t.shape, numLocs) && i != boxIdx && i != kpsIdx:
+					scoreData = t.data
+					scoreIdx = i
+				case boxData == nil && n == numLocs*4 && matchesBoxShape(t.shape, numLocs) && i != scoreIdx && i != kpsIdx:
+					boxData = t.data
+					boxIdx = i
+				case kpsData == nil && n == numLocs*10 && matchesKpsShape(t.shape, numLocs) && i != scoreIdx && i != boxIdx:
+					kpsData = t.data
+					kpsIdx = i
+				}
 			}
 		}
 
 		if scoreData == nil || boxData == nil {
 			continue
 		}
+
+		// Mark claimed tensors so other strides cannot reuse them.
+		if scoreIdx >= 0 {
+			used[scoreIdx] = true
+		}
+		if boxIdx >= 0 {
+			used[boxIdx] = true
+		}
+		if kpsIdx >= 0 {
+			used[kpsIdx] = true
+		}
+
+		logger.Log.Debug("scoring: face-detector stride matched",
+			"stride", stride,
+			"scoreTensor", tensorNameAt(tensors, scoreIdx),
+			"boxTensor", tensorNameAt(tensors, boxIdx),
+			"kpsTensor", tensorNameAt(tensors, kpsIdx),
+		)
 
 		found = true
 
@@ -562,6 +622,13 @@ func tensorNumElements(shape []int64) int {
 		n *= int(d)
 	}
 	return n
+}
+
+func tensorNameAt(tensors []scrfdTensor, idx int) string {
+	if idx < 0 || idx >= len(tensors) {
+		return "<none>"
+	}
+	return tensors[idx].name
 }
 
 func matchesScoreShape(shape []int64, numLocs int) bool {


### PR DESCRIPTION
## Summary
- **Root cause fix**: SCRFD multi-stride parser matched ONNX tensors by element count alone, causing cross-stride collisions (stride-8 scores = stride-16 boxes = 12800 elements). Box data interpreted as confidence scores produced 7000+ false face detections per photo, rendered as a red overlay.
- **Fix**: Name-based tensor matching first (score_8, bbox_16, etc.), then size-based fallback with used-tensor tracking to prevent reuse.
- **UX improvements**: Default face overlay to OFF, add "Re-analyze from scratch" button to clear stale AI data.

## Test plan
- [x] New unit tests for name-based and fallback tensor matching
- [x] All 18 packages pass with race detector
- [x] Frontend type-checks clean (`tsc --noEmit`)
- [ ] Manual: Run "Re-analyze from scratch" on a folder with existing bad data — face count should drop from thousands to single digits
- [ ] Manual: Toggle face overlay on/off with eye icon in viewer