### PR TITLE
fix(vlm): extract llama-server zip instead of exec'ing the archive

### DIFF
--- a/internal/app/ai_methods.go
+++ b/internal/app/ai_methods.go
@@ -957,11 +957,19 @@ func (a *App) DownloadVLMModel(modelName string) error {
 	return nil
 }
 
-// provisionLlamaServer downloads the llama-server binary if not already present.
+// provisionLlamaServer downloads and extracts the llama-server runtime if the
+// on-disk state is not already usable.
+//
+// The llama.cpp release ships the binary plus its shared libraries inside a
+// zip under "build/bin/". We download that zip to a dedicated staging path
+// (never the binary path — a previous version of this function wrote the zip
+// to the binary path, and would-be exec of the zip failed silently at runtime),
+// verify its SHA256, extract the allow-listed runtime files, and delete the zip.
+// See vlm.ExtractLlamaServerZip for the allowlist.
 func (a *App) provisionLlamaServer(cullsnapDir string) error {
 	binaryPath := vlm.LlamaServerBinaryPath(cullsnapDir)
-	if _, err := os.Stat(binaryPath); err == nil {
-		logger.Log.Debug("app: llama-server already provisioned", "path", binaryPath)
+	if vlm.LlamaServerRuntimeReady(cullsnapDir) {
+		logger.Log.Debug("app: llama-server runtime already present", "path", binaryPath)
 		return nil
 	}
 
@@ -981,16 +989,39 @@ func (a *App) provisionLlamaServer(cullsnapDir string) error {
 		return fmt.Errorf("no llama-server SHA256 registered for %s/%s — refusing to download unverified binary", stdruntime.GOOS, stdruntime.GOARCH)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(binaryPath), 0o755); err != nil {
-		return err
+	binDir := filepath.Dir(binaryPath)
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		return fmt.Errorf("create llama-server bin dir: %w", err)
 	}
 
-	_, err := vlm.DownloadFileResumable(a.ctx, url, binaryPath, expectedSHA, nil)
-	if err != nil {
-		return err
+	// Legacy installs wrote the zip straight to binaryPath. Remove that so the
+	// new flow can cleanly write the extracted binary to the same location
+	// without a hash-mismatch loop inside DownloadFileResumable.
+	if isZip, _ := vlm.IsLegacyZipAtBinaryPath(binaryPath); isZip {
+		logger.Log.Warn("app: removing legacy zip-as-binary before re-provisioning", "path", binaryPath)
+		if err := os.Remove(binaryPath); err != nil {
+			return fmt.Errorf("remove legacy zip-as-binary: %w", err)
+		}
 	}
 
-	return os.Chmod(binaryPath, 0o755)
+	zipPath := vlm.LlamaServerZipPath(cullsnapDir)
+	if _, err := vlm.DownloadFileResumable(a.ctx, url, zipPath, expectedSHA, nil); err != nil {
+		return fmt.Errorf("download llama-server zip: %w", err)
+	}
+
+	if _, err := vlm.ExtractLlamaServerZip(zipPath, binDir); err != nil {
+		return fmt.Errorf("extract llama-server zip: %w", err)
+	}
+
+	if err := os.Remove(zipPath); err != nil && !os.IsNotExist(err) {
+		logger.Log.Warn("app: could not remove llama-server zip after extract",
+			"path", zipPath, "err", err)
+	}
+
+	if _, err := os.Stat(binaryPath); err != nil {
+		return fmt.Errorf("llama-server binary missing after extract: %w", err)
+	}
+	return nil
 }
 
 // mustMarshalJSON marshals v to JSON, returning "[]" on error.

--- a/internal/vlm/extract.go
+++ b/internal/vlm/extract.go
@@ -1,0 +1,283 @@
+package vlm
+
+import (
+	"archive/zip"
+	"cullsnap/internal/logger"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// llamaZipEntryPrefix is the subdirectory inside llama.cpp release zips where
+// the runtime artifacts live. Everything outside this prefix is ignored.
+const llamaZipEntryPrefix = "build/bin/"
+
+// zipMagic is the standard local-file-header signature at the start of every
+// ZIP archive. Used to detect legacy installations where a previous buggy
+// provisioner wrote the zip straight to the binary path.
+var zipMagic = []byte{0x50, 0x4B, 0x03, 0x04}
+
+// LlamaServerZipPath returns the local staging location for the downloaded
+// llama.cpp release zip. It deliberately lives next to the extracted binary
+// so we can remove it with a single known path after extraction succeeds,
+// while never colliding with LlamaServerBinaryPath.
+func LlamaServerZipPath(cullsnapDir string) string {
+	return filepath.Join(cullsnapDir, binSubdir, "llama-server.zip")
+}
+
+// LlamaServerRuntimeReady reports whether an extracted llama-server runtime
+// appears usable: the binary exists and at least one of the core shared
+// libraries (libllama.dylib or libllama.so) is co-located with it so the
+// @loader_path / $ORIGIN rpath resolves at exec time.
+//
+// This is a cheap readiness check — it does not actually run the binary. It
+// replaces the previous "binary exists" shortcut, which returned true for the
+// legacy state where the zip itself sat at the binary path.
+func LlamaServerRuntimeReady(cullsnapDir string) bool {
+	binaryPath := LlamaServerBinaryPath(cullsnapDir)
+	info, err := os.Stat(binaryPath)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	isZip, _ := isZipFile(binaryPath)
+	if isZip {
+		if logger.Log != nil {
+			logger.Log.Debug("vlm: legacy zip-as-binary detected at llama-server path",
+				"path", binaryPath)
+		}
+		return false
+	}
+	dir := filepath.Dir(binaryPath)
+	for _, lib := range []string{"libllama.dylib", "libllama.so"} {
+		if _, err := os.Stat(filepath.Join(dir, lib)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// ExtractLlamaServerZip extracts the runtime artifacts from a llama.cpp
+// release zip into destDir. It:
+//   - Strips the "build/bin/" prefix so the extracted files sit directly in
+//     destDir (required for macOS @loader_path / Linux $ORIGIN rpath lookups).
+//   - Refuses entries that resolve outside destDir after cleaning (zip-slip).
+//   - Filters members through llamaZipMemberKept so only runtime-necessary
+//     files land on disk (binary, shared libraries, Metal shader, license
+//     files). Other bundled binaries (llama-bench, llama-cli, ...) are skipped.
+//   - Chmods the main binary to 0o755 regardless of the mode recorded in the
+//     zip, since zip archives on Windows-hosted CI sometimes drop the exec bit.
+//
+// Returns the count of files written. destDir is created if missing.
+func ExtractLlamaServerZip(zipPath, destDir string) (int, error) {
+	if logger.Log != nil {
+		logger.Log.Debug("vlm: extracting llama-server zip",
+			"zip", zipPath, "dest", destDir)
+	}
+
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return 0, fmt.Errorf("vlm: mkdir extract dest: %w", err)
+	}
+
+	// filepath.Clean once so every zip-slip check compares against a canonical
+	// form (trailing separators stripped, ".." resolved within destDir).
+	cleanDest, err := filepath.Abs(filepath.Clean(destDir))
+	if err != nil {
+		return 0, fmt.Errorf("vlm: resolve extract dest: %w", err)
+	}
+
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return 0, fmt.Errorf("vlm: open zip: %w", err)
+	}
+	defer r.Close() //nolint:errcheck // read-only zip close
+
+	binaryName := "llama-server"
+	var written int
+	for _, entry := range r.File {
+		if entry.FileInfo().IsDir() {
+			continue
+		}
+		rel, ok := strings.CutPrefix(entry.Name, llamaZipEntryPrefix)
+		if !ok || rel == "" {
+			continue
+		}
+		if !llamaZipMemberKept(rel) {
+			continue
+		}
+
+		outPath, slipErr := safeJoin(cleanDest, rel)
+		if slipErr != nil {
+			return written, slipErr
+		}
+
+		if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+			return written, fmt.Errorf("vlm: mkdir for %q: %w", rel, err)
+		}
+
+		if err := writeZipEntry(entry, outPath); err != nil {
+			return written, err
+		}
+		written++
+	}
+
+	binaryPath := filepath.Join(cleanDest, binaryName)
+	if err := os.Chmod(binaryPath, 0o755); err != nil {
+		return written, fmt.Errorf("vlm: chmod llama-server binary: %w", err)
+	}
+
+	if logger.Log != nil {
+		logger.Log.Debug("vlm: llama-server zip extraction complete",
+			"files_written", written, "dest", cleanDest)
+	}
+	return written, nil
+}
+
+// llamaZipMemberKept reports whether a zip entry (with llamaZipEntryPrefix
+// already stripped) should be written to disk. The allowlist is deliberately
+// conservative: the VLM backend only needs the llama-server process and its
+// runtime dependencies, so we skip the dozen other CLI binaries in the
+// release to save disk space and reduce install surface area.
+func llamaZipMemberKept(rel string) bool {
+	base := filepath.Base(rel)
+	if base == "llama-server" || base == "llama-server.exe" {
+		return true
+	}
+	// Shared libraries — macOS .dylib, Linux .so(+version), Windows .dll.
+	if strings.HasPrefix(base, "lib") &&
+		(strings.HasSuffix(base, ".dylib") || containsDotSo(base) || strings.HasSuffix(base, ".dll")) {
+		return true
+	}
+	// Metal compute shader + its headers (macOS arm64 GPU backend).
+	if strings.HasSuffix(base, ".metal") || strings.HasSuffix(base, ".h") {
+		return true
+	}
+	// License / notice files for compliance when redistributing binaries.
+	if strings.HasPrefix(base, "LICENSE") || strings.HasPrefix(base, "NOTICE") {
+		return true
+	}
+	return false
+}
+
+// containsDotSo matches both plain "libfoo.so" and versioned "libfoo.so.1.2"
+// names that show up in some Linux llama.cpp release packages.
+func containsDotSo(name string) bool {
+	return strings.HasSuffix(name, ".so") || strings.Contains(name, ".so.")
+}
+
+// safeJoin returns filepath.Join(base, rel) after rejecting any rel that
+// escapes base via absolute paths, "..", or symlinks encoded in the zip.
+// Returns a typed error so callers can identify the attack signature in logs.
+func safeJoin(base, rel string) (string, error) {
+	if filepath.IsAbs(rel) {
+		return "", fmt.Errorf("vlm: zip entry %q uses absolute path (zip-slip)", rel)
+	}
+	joined := filepath.Join(base, rel)
+	cleaned, err := filepath.Abs(joined)
+	if err != nil {
+		return "", fmt.Errorf("vlm: resolve zip entry path: %w", err)
+	}
+	// Trailing separator required so "/foo" does not match "/foo-bar".
+	baseWithSep := base
+	if !strings.HasSuffix(baseWithSep, string(os.PathSeparator)) {
+		baseWithSep += string(os.PathSeparator)
+	}
+	if cleaned != base && !strings.HasPrefix(cleaned, baseWithSep) {
+		return "", fmt.Errorf("vlm: zip entry %q escapes destination (zip-slip)", rel)
+	}
+	return cleaned, nil
+}
+
+// writeZipEntry copies a single zip.File to outPath using atomic
+// create-write-rename semantics: a .tmp sibling is written first, then
+// renamed over outPath so a crash mid-write never leaves a half-extracted
+// binary that later "looks ready".
+func writeZipEntry(entry *zip.File, outPath string) error {
+	tmpPath := outPath + ".tmp"
+	rc, err := entry.Open()
+	if err != nil {
+		return fmt.Errorf("vlm: open zip entry %q: %w", entry.Name, err)
+	}
+	defer rc.Close() //nolint:errcheck // read-only zip entry close
+
+	mode := entry.Mode()
+	if mode == 0 {
+		mode = 0o644
+	}
+
+	// Use a named function so the copy+sync+close+rename sequence has a
+	// single recovery path (remove the .tmp) that handles every error case
+	// without the double-close pitfall of deferring Close while also
+	// calling it explicitly before Rename.
+	err = writeAtomic(tmpPath, outPath, mode.Perm(), rc, entry.Name)
+	if err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}
+
+// writeAtomic copies src into tmpPath, syncs+closes, then renames to outPath.
+// Any failure after OpenFile means the caller should unlink tmpPath.
+func writeAtomic(tmpPath, outPath string, perm os.FileMode, src io.Reader, entryName string) error {
+	f, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, perm)
+	if err != nil {
+		return fmt.Errorf("vlm: open extract target %q: %w", outPath, err)
+	}
+	if _, err := io.Copy(f, src); err != nil { //nolint:gosec // zip members already filtered by llamaZipMemberKept
+		_ = f.Close()
+		return fmt.Errorf("vlm: copy zip entry %q: %w", entryName, err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("vlm: sync extract target %q: %w", outPath, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("vlm: close extract target %q: %w", outPath, err)
+	}
+	if err := os.Rename(tmpPath, outPath); err != nil {
+		return fmt.Errorf("vlm: rename extract target %q: %w", outPath, err)
+	}
+	return nil
+}
+
+// IsLegacyZipAtBinaryPath reports whether the file at binaryPath is actually
+// a ZIP archive. Earlier versions of provisionLlamaServer downloaded the
+// llama.cpp release zip directly to the binary path without extracting,
+// leaving a non-executable file that failed silently at exec time. This
+// predicate lets the upgrade path detect that state and recover. Returns
+// false (without error) when the path does not exist.
+func IsLegacyZipAtBinaryPath(binaryPath string) (bool, error) {
+	return isZipFile(binaryPath)
+}
+
+// isZipFile returns true when path begins with the ZIP local-file-header
+// signature. Used to detect legacy installs where the zip was saved to the
+// binary path.
+func isZipFile(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	defer f.Close() //nolint:errcheck // read-only check
+
+	buf := make([]byte, len(zipMagic))
+	n, err := io.ReadFull(f, buf)
+	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
+		return false, err
+	}
+	if n < len(zipMagic) {
+		return false, nil
+	}
+	for i, b := range zipMagic {
+		if buf[i] != b {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/internal/vlm/extract_test.go
+++ b/internal/vlm/extract_test.go
@@ -1,0 +1,307 @@
+package vlm
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// zipBuilder assembles an in-memory zip and writes it to a temp file for each
+// test. Tests describe the zip declaratively (name + mode + bytes) so failure
+// messages point at the construction rather than byte-level reader setup.
+type zipEntrySpec struct {
+	name string
+	mode os.FileMode
+	body []byte
+}
+
+func buildTestZip(t *testing.T, entries []zipEntrySpec) string {
+	t.Helper()
+	var buf bytes.Buffer
+	w := zip.NewWriter(&buf)
+	for _, e := range entries {
+		mode := e.mode
+		if mode == 0 {
+			mode = 0o644
+		}
+		fh := &zip.FileHeader{Name: e.name, Method: zip.Deflate}
+		fh.SetMode(mode)
+		fw, err := w.CreateHeader(fh)
+		if err != nil {
+			t.Fatalf("build zip: create header %q: %v", e.name, err)
+		}
+		if _, err := fw.Write(e.body); err != nil {
+			t.Fatalf("build zip: write %q: %v", e.name, err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("build zip: close: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "test.zip")
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatalf("build zip: write file: %v", err)
+	}
+	return path
+}
+
+// TestExtractLlamaServerZipHappyPath exercises a minimal realistic zip layout
+// and verifies that every allow-listed runtime file lands in destDir, that
+// the binary gets an executable bit regardless of what the archive recorded,
+// and that the "build/bin/" prefix is stripped so @loader_path / $ORIGIN
+// rpath resolution works.
+func TestExtractLlamaServerZipHappyPath(t *testing.T) {
+	zipPath := buildTestZip(t, []zipEntrySpec{
+		{name: "build/bin/llama-server", mode: 0o644, body: []byte("#!/bin/sh\necho fake\n")},
+		{name: "build/bin/libllama.dylib", mode: 0o644, body: []byte("lib-llama-bytes")},
+		{name: "build/bin/libggml-metal.dylib", mode: 0o644, body: []byte("metal-bytes")},
+		{name: "build/bin/ggml-metal.metal", mode: 0o644, body: []byte("metal-shader")},
+		{name: "build/bin/ggml-common.h", mode: 0o644, body: []byte("header")},
+		{name: "build/bin/LICENSE", mode: 0o644, body: []byte("license text")},
+		// These should NOT be extracted — wasted disk otherwise.
+		{name: "build/bin/llama-bench", mode: 0o755, body: []byte("other bin")},
+		{name: "build/bin/llama-cli", mode: 0o755, body: []byte("other bin")},
+		{name: "README.md", mode: 0o644, body: []byte("ignored")},
+	})
+
+	dest := t.TempDir()
+	written, err := ExtractLlamaServerZip(zipPath, dest)
+	if err != nil {
+		t.Fatalf("ExtractLlamaServerZip: %v", err)
+	}
+	// 6 allow-listed: binary + 2 libs + .metal + .h + LICENSE
+	const wantWritten = 6
+	if written != wantWritten {
+		t.Errorf("extracted %d files, want %d", written, wantWritten)
+	}
+
+	expectedPresent := []string{"llama-server", "libllama.dylib", "libggml-metal.dylib", "ggml-metal.metal", "ggml-common.h", "LICENSE"}
+	for _, name := range expectedPresent {
+		if _, err := os.Stat(filepath.Join(dest, name)); err != nil {
+			t.Errorf("expected %s at dest, got stat err: %v", name, err)
+		}
+	}
+
+	expectedAbsent := []string{"llama-bench", "llama-cli", "README.md"}
+	for _, name := range expectedAbsent {
+		if _, err := os.Stat(filepath.Join(dest, name)); err == nil {
+			t.Errorf("%s was extracted but should have been filtered out", name)
+		}
+	}
+
+	// Binary must be executable even though the zip entry was 0o644.
+	binInfo, err := os.Stat(filepath.Join(dest, "llama-server"))
+	if err != nil {
+		t.Fatalf("stat extracted binary: %v", err)
+	}
+	if binInfo.Mode().Perm()&0o111 == 0 {
+		t.Errorf("llama-server mode %v is not executable", binInfo.Mode())
+	}
+}
+
+// TestExtractLlamaServerZipLinuxSharedObjects confirms the filter accepts the
+// ".so" naming convention used by the ubuntu-x64 release zip.
+func TestExtractLlamaServerZipLinuxSharedObjects(t *testing.T) {
+	zipPath := buildTestZip(t, []zipEntrySpec{
+		{name: "build/bin/llama-server", body: []byte("bin")},
+		{name: "build/bin/libllama.so", body: []byte("so")},
+		{name: "build/bin/libggml.so.1", body: []byte("versioned so")},
+	})
+	dest := t.TempDir()
+	_, err := ExtractLlamaServerZip(zipPath, dest)
+	if err != nil {
+		t.Fatalf("ExtractLlamaServerZip: %v", err)
+	}
+	for _, name := range []string{"llama-server", "libllama.so", "libggml.so.1"} {
+		if _, err := os.Stat(filepath.Join(dest, name)); err != nil {
+			t.Errorf("expected %s at dest, got stat err: %v", name, err)
+		}
+	}
+}
+
+// TestExtractLlamaServerZipRejectsZipSlip asserts we refuse to write outside
+// destDir when the entry name uses "..". These are the only zip-slip vectors
+// that survive the "build/bin/" prefix filter — absolute paths and names
+// missing the prefix are silently skipped before reaching path resolution.
+func TestExtractLlamaServerZipRejectsZipSlip(t *testing.T) {
+	cases := []string{
+		"build/bin/../../../llama-server",
+		"build/bin/../llama-server",
+	}
+	for _, evil := range cases {
+		t.Run(evil, func(t *testing.T) {
+			zipPath := buildTestZip(t, []zipEntrySpec{
+				{name: "build/bin/llama-server", body: []byte("ok")},
+				{name: evil, body: []byte("evil")},
+			})
+			_, err := ExtractLlamaServerZip(zipPath, t.TempDir())
+			if err == nil || !strings.Contains(err.Error(), "zip-slip") {
+				t.Fatalf("expected zip-slip error, got %v", err)
+			}
+		})
+	}
+}
+
+// TestExtractLlamaServerZipSilentlyDropsOutOfPrefix verifies that entry
+// names outside the "build/bin/" allowlist (absolute paths, top-level files,
+// nested siblings) are quietly filtered rather than raising an error. The
+// filter runs before path resolution, so a malicious archive that only
+// contains out-of-prefix entries produces no output files and no extraction.
+func TestExtractLlamaServerZipSilentlyDropsOutOfPrefix(t *testing.T) {
+	zipPath := buildTestZip(t, []zipEntrySpec{
+		{name: "build/bin/llama-server", body: []byte("ok")},
+		{name: "build/bin/libllama.dylib", body: []byte("ok")},
+		{name: "/tmp/llama-server", body: []byte("evil-abs-path")},
+		{name: "other/llama-server", body: []byte("evil-sibling")},
+	})
+	dest := t.TempDir()
+	n, err := ExtractLlamaServerZip(zipPath, dest)
+	if err != nil {
+		t.Fatalf("ExtractLlamaServerZip: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("extracted %d, want 2", n)
+	}
+	if _, err := os.Stat("/tmp/llama-server.tmp"); err == nil {
+		t.Fatal("SECURITY: extractor wrote /tmp/llama-server — abs-path filter broken")
+	}
+}
+
+// TestExtractLlamaServerZipMissingBinaryChmodFails documents the invariant:
+// if the zip has no llama-server entry, the post-extract chmod fails because
+// there is nothing to chmod. The error is explicit so callers know the
+// archive was malformed rather than silently producing a broken runtime.
+func TestExtractLlamaServerZipMissingBinaryChmodFails(t *testing.T) {
+	zipPath := buildTestZip(t, []zipEntrySpec{
+		{name: "build/bin/libllama.dylib", body: []byte("lib")},
+	})
+	_, err := ExtractLlamaServerZip(zipPath, t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "chmod llama-server binary") {
+		t.Fatalf("expected chmod-missing error, got %v", err)
+	}
+}
+
+// TestIsLegacyZipAtBinaryPathDetectsZip and TestIsLegacyZipAtBinaryPathIgnoresBinary
+// together cover the upgrade-recovery predicate used by provisionLlamaServer.
+func TestIsLegacyZipAtBinaryPathDetectsZip(t *testing.T) {
+	zipPath := buildTestZip(t, []zipEntrySpec{{name: "foo", body: []byte("bar")}})
+	got, err := IsLegacyZipAtBinaryPath(zipPath)
+	if err != nil {
+		t.Fatalf("IsLegacyZipAtBinaryPath err = %v", err)
+	}
+	if !got {
+		t.Error("expected IsLegacyZipAtBinaryPath to detect zip magic")
+	}
+}
+
+func TestIsLegacyZipAtBinaryPathIgnoresBinary(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "fake-binary")
+	// Mach-O 64 magic so this does not accidentally start with "PK\x03\x04".
+	if err := os.WriteFile(path, []byte{0xCF, 0xFA, 0xED, 0xFE, 0x01, 0x02, 0x03, 0x04}, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := IsLegacyZipAtBinaryPath(path)
+	if err != nil {
+		t.Fatalf("IsLegacyZipAtBinaryPath err = %v", err)
+	}
+	if got {
+		t.Error("expected IsLegacyZipAtBinaryPath to return false for non-zip file")
+	}
+}
+
+func TestIsLegacyZipAtBinaryPathMissingFile(t *testing.T) {
+	got, err := IsLegacyZipAtBinaryPath(filepath.Join(t.TempDir(), "nope"))
+	if err != nil {
+		t.Fatalf("missing file should not error, got %v", err)
+	}
+	if got {
+		t.Error("missing file should report false")
+	}
+}
+
+// TestLlamaServerRuntimeReadyDetectsAllStates covers the three states that
+// the provisioner distinguishes: no install, legacy zip-at-binary, and a
+// proper extracted layout. The decision logic is load-bearing for whether
+// provisionLlamaServer decides to download + extract or short-circuit.
+func TestLlamaServerRuntimeReadyDetectsAllStates(t *testing.T) {
+	cullsnapDir := t.TempDir()
+	binDir := filepath.Join(cullsnapDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	binaryPath := LlamaServerBinaryPath(cullsnapDir)
+
+	// State 1: no install.
+	if LlamaServerRuntimeReady(cullsnapDir) {
+		t.Fatal("no install should not be ready")
+	}
+
+	// State 2: legacy zip-as-binary.
+	zipBody := buildTestZip(t, []zipEntrySpec{{name: "anything", body: []byte("x")}})
+	src, err := os.ReadFile(zipBody)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(binaryPath, src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if LlamaServerRuntimeReady(cullsnapDir) {
+		t.Error("legacy zip-as-binary state should not be ready")
+	}
+
+	// State 3: extracted binary + libllama side-by-side.
+	if err := os.WriteFile(binaryPath, []byte{0xCF, 0xFA, 0xED, 0xFE}, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "libllama.dylib"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !LlamaServerRuntimeReady(cullsnapDir) {
+		t.Error("binary + libllama should register as ready")
+	}
+}
+
+// TestLlamaZipMemberKept pins down the allowlist so future changes to the
+// filter are visible in the review diff rather than silently shrinking or
+// growing what lands on users' disks.
+func TestLlamaZipMemberKept(t *testing.T) {
+	keep := []string{
+		"llama-server", "llama-server.exe",
+		"libllama.dylib", "libggml.dylib", "libggml-metal.dylib",
+		"libllama.so", "libggml.so.1",
+		"libllama.dll",
+		"ggml-metal.metal", "ggml-common.h",
+		"LICENSE", "LICENSE-curl", "NOTICE",
+	}
+	skip := []string{
+		"llama-bench", "llama-cli", "llama-embedding",
+		"README.md",
+		"some-random-file",
+	}
+	for _, name := range keep {
+		if !llamaZipMemberKept(name) {
+			t.Errorf("expected %q to be kept", name)
+		}
+	}
+	for _, name := range skip {
+		if llamaZipMemberKept(name) {
+			t.Errorf("expected %q to be skipped", name)
+		}
+	}
+}
+
+// TestLlamaServerZipPath anchors the staging location so it never collides
+// with LlamaServerBinaryPath — the precise bug this PR is fixing.
+func TestLlamaServerZipPath(t *testing.T) {
+	const root = "/home/user/.cullsnap"
+	zipPath := LlamaServerZipPath(root)
+	binPath := LlamaServerBinaryPath(root)
+	if zipPath == binPath {
+		t.Errorf("LlamaServerZipPath (%q) must differ from LlamaServerBinaryPath (%q)", zipPath, binPath)
+	}
+	if filepath.Ext(zipPath) != ".zip" {
+		t.Errorf("expected .zip extension on zip path, got %q", zipPath)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #129.

\`provisionLlamaServer\` was downloading the llama.cpp release zip directly
to the path that \`LlamaCppBackend\` later tries to \`exec\`. The zip was never
unpacked, so every attempt to spawn \`llama-server\` was a no-op — VLM scoring
was broken for every user who did not already have llama-server extracted on
their machine.

This PR adds proper extraction with atomic per-file writes, zip-slip
hardening, and upgrade recovery for the legacy "zip at binary path" state.

## Behavior changes

### Extraction (\`ExtractLlamaServerZip\`)

- Strips the \`build/bin/\` prefix so the extracted files sit in \`~/.cullsnap/bin/\`,
  which is what \`@loader_path\` on macOS and \`$ORIGIN\` on Linux need for the
  shared libraries to resolve at exec time.
- Allow-lists only runtime-necessary members: \`llama-server\`, shared libs
  (\`.dylib\`, \`.so\`(+version), \`.dll\`), Metal shader (\`.metal\` + headers),
  and \`LICENSE\`/\`NOTICE\` files for redistribution compliance. Bundled
  utilities (\`llama-bench\`, \`llama-cli\`, \`llama-embedding\`, etc.) are
  skipped — we don't use them and they bloat the install.
- Writes every entry atomically (\`<file>.tmp\` → \`fsync\` → \`close\` →
  \`rename\`) so a crash mid-extract can't leave a half-extracted binary
  that later passes the "looks ready" check.
- Force-chmods the binary to \`0o755\` after extraction. Some Windows-hosted
  CI systems drop the executable bit on \`.dylib\` / unix binaries.

### Path resolution hardening

- \`safeJoin\` rejects absolute-path entries and any \`..\`-traversed names
  that resolve outside the destination after \`filepath.Clean\`.
- Out-of-prefix entries (anything not under \`build/bin/\`) are silently
  dropped before path resolution — verified by test that no file lands
  at \`/tmp/llama-server.tmp\`.

### Provisioner flow (\`provisionLlamaServer\`)

- \`LlamaServerRuntimeReady\` replaces the old "binary exists" shortcut.
  It accepts an install only when:
  1. \`llama-server\` exists at the expected path,
  2. the file is not itself a zip (upgrade-recovery predicate), and
  3. a core shared library (\`libllama.dylib\` or \`libllama.so\`) is
     co-located so \`@loader_path\` / \`$ORIGIN\` resolution works.
- \`LlamaServerZipPath\` ("\`~/.cullsnap/bin/llama-server.zip\`") is used as
  the download staging path. This separates the integrity-verified zip
  from the extracted binary path, closing the loop where the previous
  flow would verify a zip and then try to exec it.
- \`IsLegacyZipAtBinaryPath\` detects the old "zip saved at binary path"
  state on upgrade. The legacy file is unlinked before re-provisioning,
  so \`DownloadFileResumable\`'s new cache-reverify logic (from #130) does
  not loop on a hash mismatch.

## Verified against a real release

Extracted \`llama-b5280-bin-macos-arm64.zip\` into a temp dir and ran
\`llama-server --version\`:

\`\`\`
version: 5280 (27aa2595)
built with Apple clang version 15.0.0 (clang-1500.3.9.4) for arm64-apple-darwin23.6.0
\`\`\`

So \`@loader_path\` resolves correctly when the dylibs are written next to
the binary.

## Tests

All green with \`-race\`; \`internal/vlm\` coverage 59.2% (up from 57.4%).

- \`TestExtractLlamaServerZipHappyPath\` — synthetic zip with 9 members,
  verifies only the 6 allow-listed files land, prefix is stripped, and
  the binary is executable even though the source mode was \`0o644\`.
- \`TestExtractLlamaServerZipLinuxSharedObjects\` — \`.so\` and \`.so.1\`
  naming are accepted for the ubuntu-x64 release shape.
- \`TestExtractLlamaServerZipRejectsZipSlip\` — \`build/bin/../../../foo\`
  and \`build/bin/../foo\` variants raise \`zip-slip\` errors.
- \`TestExtractLlamaServerZipSilentlyDropsOutOfPrefix\` — abs-path and
  top-level entries are silently skipped; regression guard that no
  \`/tmp/llama-server.tmp\` leaks.
- \`TestExtractLlamaServerZipMissingBinaryChmodFails\` — archives without
  the binary surface an explicit chmod error rather than producing a
  broken runtime.
- \`TestIsLegacyZipAtBinaryPath{DetectsZip,IgnoresBinary,MissingFile}\` —
  cover the three states of the upgrade-recovery predicate.
- \`TestLlamaServerRuntimeReadyDetectsAllStates\` — no-install,
  legacy zip-as-binary, extracted layout.
- \`TestLlamaZipMemberKept\` — pins the allowlist so future filter changes
  are visible in diffs.
- \`TestLlamaServerZipPath\` — regression guard: staging path must differ
  from the binary path.

## Test plan

- [x] \`go build ./internal/...\`
- [x] \`go test -race ./internal/...\`
- [x] \`go vet ./internal/...\`
- [x] \`gofmt -l\` clean on touched files
- [x] Real b5280 macos-arm64 zip extracted and \`llama-server --version\` runs
- [ ] CI green on push (linters / govulncheck / gitleaks / frontend tsc)