### PR TITLE
fix(storage): ClearAIData now also clears VLM scores and rankings

### DIFF
--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -872,30 +872,37 @@ func (s *SQLiteStore) HideFaceCluster(clusterID int64, hidden bool) error {
 	return nil
 }
 
-// DeleteAIDataForFolder removes all AI scores, face detections, and face clusters for a folder.
+// DeleteAIDataForFolder removes every trace of AI analysis for a folder —
+// ONNX outputs (face detections, face clusters, ai_scores) and VLM outputs
+// (vlm_scores, vlm_rankings, vlm_ranking_groups). The six DELETEs run inside
+// a single transaction so a failure partway through cannot leave users with
+// e.g. cleared face data but stale VLM explanations still showing in the UI.
+//
+// Calls deleteVLMDataForFolderLocked for the VLM half rather than the public
+// DeleteVLMDataForFolder to avoid re-entering s.mu (which would deadlock).
 func (s *SQLiteStore) DeleteAIDataForFolder(folderPath string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Delete detections for photos in this folder
-	_, err := s.db.Exec(`DELETE FROM face_detections WHERE photo_path LIKE ?`, folderPath+"/%")
+	tx, err := s.db.Begin()
 	if err != nil {
+		return fmt.Errorf("begin AI data delete tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }() //nolint:errcheck // no-op after Commit
+
+	if _, err := tx.Exec(`DELETE FROM face_detections WHERE photo_path LIKE ?`, folderPath+"/%"); err != nil {
 		return fmt.Errorf("failed to delete face detections: %w", err)
 	}
-
-	// Delete clusters for this folder
-	_, err = s.db.Exec(`DELETE FROM face_clusters WHERE folder_path = ?`, folderPath)
-	if err != nil {
+	if _, err := tx.Exec(`DELETE FROM face_clusters WHERE folder_path = ?`, folderPath); err != nil {
 		return fmt.Errorf("failed to delete face clusters: %w", err)
 	}
-
-	// Delete scores for photos in this folder
-	_, err = s.db.Exec(`DELETE FROM ai_scores WHERE photo_path LIKE ?`, folderPath+"/%")
-	if err != nil {
+	if _, err := tx.Exec(`DELETE FROM ai_scores WHERE photo_path LIKE ?`, folderPath+"/%"); err != nil {
 		return fmt.Errorf("failed to delete AI scores: %w", err)
 	}
-
-	return nil
+	if err := deleteVLMDataForFolderTx(tx, folderPath); err != nil {
+		return err
+	}
+	return tx.Commit()
 }
 
 // DeleteFaceClustersForFolder removes face clusters for a folder and resets
@@ -1016,17 +1023,37 @@ func (s *SQLiteStore) GetVLMScoresForFolder(folderPath string) ([]VLMScoreRow, e
 }
 
 // DeleteVLMDataForFolder removes all VLM scores, rankings, and ranking groups for a folder.
+//
+// The three DELETEs share a transaction so a partial failure cannot leave
+// the folder with ranking rows whose parent scores were already removed.
 func (s *SQLiteStore) DeleteVLMDataForFolder(folderPath string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, err := s.db.Exec(`DELETE FROM vlm_scores WHERE folder_path = ?`, folderPath); err != nil {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return fmt.Errorf("begin VLM data delete tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }() //nolint:errcheck // no-op after Commit
+
+	if err := deleteVLMDataForFolderTx(tx, folderPath); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// deleteVLMDataForFolderTx issues the three VLM DELETEs on an existing
+// transaction. Callers are responsible for holding s.mu (if applicable) and
+// for Commit/Rollback. Shared by DeleteVLMDataForFolder and
+// DeleteAIDataForFolder to keep the delete list in one place.
+func deleteVLMDataForFolderTx(tx *sql.Tx, folderPath string) error {
+	if _, err := tx.Exec(`DELETE FROM vlm_scores WHERE folder_path = ?`, folderPath); err != nil {
 		return fmt.Errorf("failed to delete VLM scores: %w", err)
 	}
-	if _, err := s.db.Exec(`DELETE FROM vlm_rankings WHERE folder_path = ?`, folderPath); err != nil {
+	if _, err := tx.Exec(`DELETE FROM vlm_rankings WHERE folder_path = ?`, folderPath); err != nil {
 		return fmt.Errorf("failed to delete VLM rankings: %w", err)
 	}
-	if _, err := s.db.Exec(`DELETE FROM vlm_ranking_groups WHERE folder_path = ?`, folderPath); err != nil {
+	if _, err := tx.Exec(`DELETE FROM vlm_ranking_groups WHERE folder_path = ?`, folderPath); err != nil {
 		return fmt.Errorf("failed to delete VLM ranking groups: %w", err)
 	}
 	return nil

--- a/internal/storage/sqlite_vlm_test.go
+++ b/internal/storage/sqlite_vlm_test.go
@@ -147,6 +147,133 @@ func TestGetVLMScoreNotFound(t *testing.T) {
 	}
 }
 
+// TestDeleteAIDataForFolderClearsVLM is the regression test for #116:
+// "Clear AI Data" (which calls DeleteAIDataForFolder) must wipe every AI
+// artifact for a folder, including VLM scores, rankings, and ranking groups.
+// Before this test was added, VLM data survived the clear and the UI
+// continued showing stale explanations after re-analysis.
+func TestDeleteAIDataForFolderClearsVLM(t *testing.T) {
+	store := newTestStore(t)
+
+	folder := "/photos/vacation"
+	keepFolder := "/photos/other"
+
+	// --- Seed every table DeleteAIDataForFolder should touch. ---
+	if err := store.SaveAIScore(&AIScore{
+		PhotoPath: folder + "/a.jpg", OverallScore: 0.9, FaceCount: 1, Provider: "Local ONNX",
+	}); err != nil {
+		t.Fatalf("SaveAIScore target: %v", err)
+	}
+	if err := store.SaveAIScore(&AIScore{
+		PhotoPath: keepFolder + "/x.jpg", OverallScore: 0.5, FaceCount: 0, Provider: "Local ONNX",
+	}); err != nil {
+		t.Fatalf("SaveAIScore other: %v", err)
+	}
+
+	if _, err := store.SaveFaceDetection(&FaceDetection{
+		PhotoPath: folder + "/a.jpg", BboxX: 0, BboxY: 0, BboxW: 10, BboxH: 10, Confidence: 0.99,
+	}); err != nil {
+		t.Fatalf("SaveFaceDetection target: %v", err)
+	}
+	if _, err := store.SaveFaceDetection(&FaceDetection{
+		PhotoPath: keepFolder + "/x.jpg", BboxX: 0, BboxY: 0, BboxW: 10, BboxH: 10, Confidence: 0.99,
+	}); err != nil {
+		t.Fatalf("SaveFaceDetection other: %v", err)
+	}
+
+	if _, err := store.SaveFaceCluster(&FaceCluster{
+		FolderPath: folder, Label: "Person 1", PhotoCount: 1,
+	}); err != nil {
+		t.Fatalf("SaveFaceCluster target: %v", err)
+	}
+	if _, err := store.SaveFaceCluster(&FaceCluster{
+		FolderPath: keepFolder, Label: "Person A", PhotoCount: 1,
+	}); err != nil {
+		t.Fatalf("SaveFaceCluster other: %v", err)
+	}
+
+	if err := store.SaveVLMScore(VLMScoreRow{
+		PhotoPath: folder + "/a.jpg", FolderPath: folder,
+		Aesthetic: 0.8, PromptVersion: 1, ScoredAt: "2026-04-09T10:00:00Z",
+	}); err != nil {
+		t.Fatalf("SaveVLMScore target: %v", err)
+	}
+	if err := store.SaveVLMScore(VLMScoreRow{
+		PhotoPath: keepFolder + "/x.jpg", FolderPath: keepFolder,
+		Aesthetic: 0.5, PromptVersion: 1, ScoredAt: "2026-04-09T10:00:00Z",
+	}); err != nil {
+		t.Fatalf("SaveVLMScore other: %v", err)
+	}
+
+	if err := store.SaveVLMRanking(VLMRankingGroupRow{
+		FolderPath: folder, GroupLabel: "burst-1", PhotoCount: 2,
+		Explanation: "target", ModelName: "gemma-4", PromptVersion: 1,
+		Rankings: []VLMRankingRow{
+			{PhotoPath: folder + "/a.jpg", Rank: 1, RelativeScore: 0.9, TokensUsed: 50},
+		},
+	}); err != nil {
+		t.Fatalf("SaveVLMRanking target: %v", err)
+	}
+	if err := store.SaveVLMRanking(VLMRankingGroupRow{
+		FolderPath: keepFolder, GroupLabel: "burst-2", PhotoCount: 1,
+		Explanation: "other", ModelName: "gemma-4", PromptVersion: 1,
+		Rankings: []VLMRankingRow{
+			{PhotoPath: keepFolder + "/x.jpg", Rank: 1, RelativeScore: 0.8, TokensUsed: 50},
+		},
+	}); err != nil {
+		t.Fatalf("SaveVLMRanking other: %v", err)
+	}
+
+	// --- Execute the clear. ---
+	if err := store.DeleteAIDataForFolder(folder); err != nil {
+		t.Fatalf("DeleteAIDataForFolder: %v", err)
+	}
+
+	// --- Target folder: every AI+VLM artifact must be gone. ---
+	if scores, err := store.GetAIScoresForFolder(folder); err != nil {
+		t.Fatalf("GetAIScoresForFolder target: %v", err)
+	} else if len(scores) != 0 {
+		t.Errorf("ai_scores for target folder: got %d, want 0", len(scores))
+	}
+	if dets, err := store.GetFaceDetections(folder + "/a.jpg"); err != nil {
+		t.Fatalf("GetFaceDetections target: %v", err)
+	} else if len(dets) != 0 {
+		t.Errorf("face_detections for target photo: got %d, want 0", len(dets))
+	}
+	if clusters, err := store.GetFaceClusters(folder); err != nil {
+		t.Fatalf("GetFaceClusters target: %v", err)
+	} else if len(clusters) != 0 {
+		t.Errorf("face_clusters for target folder: got %d, want 0", len(clusters))
+	}
+	if vlm, err := store.GetVLMScoresForFolder(folder); err != nil {
+		t.Fatalf("GetVLMScoresForFolder target: %v", err)
+	} else if len(vlm) != 0 {
+		t.Errorf("vlm_scores for target folder: got %d, want 0 — #116 regression", len(vlm))
+	}
+	if rankings, err := store.GetVLMRankingsForFolder(folder); err != nil {
+		t.Fatalf("GetVLMRankingsForFolder target: %v", err)
+	} else if len(rankings) != 0 {
+		t.Errorf("vlm_rankings for target folder: got %d, want 0 — #116 regression", len(rankings))
+	}
+
+	// --- Other folder: nothing may have been collateral damage. ---
+	if scores, err := store.GetAIScoresForFolder(keepFolder); err != nil {
+		t.Fatalf("GetAIScoresForFolder other: %v", err)
+	} else if len(scores) != 1 {
+		t.Errorf("ai_scores for other folder: got %d, want 1 (collateral damage)", len(scores))
+	}
+	if vlm, err := store.GetVLMScoresForFolder(keepFolder); err != nil {
+		t.Fatalf("GetVLMScoresForFolder other: %v", err)
+	} else if len(vlm) != 1 {
+		t.Errorf("vlm_scores for other folder: got %d, want 1 (collateral damage)", len(vlm))
+	}
+	if rankings, err := store.GetVLMRankingsForFolder(keepFolder); err != nil {
+		t.Fatalf("GetVLMRankingsForFolder other: %v", err)
+	} else if len(rankings) != 1 {
+		t.Errorf("vlm_rankings for other folder: got %d, want 1 (collateral damage)", len(rankings))
+	}
+}
+
 func TestDeleteVLMDataForFolder(t *testing.T) {
 	store := newTestStore(t)
 


### PR DESCRIPTION
## Summary

Closes #116.

\`DeleteAIDataForFolder\` — the backend of the "Clear AI Data" UI action —
used to wipe ONNX outputs (\`face_detections\`, \`face_clusters\`, \`ai_scores\`)
but leave VLM outputs (\`vlm_scores\`, \`vlm_rankings\`, \`vlm_ranking_groups\`)
intact. Users saw stale VLM explanations and pairwise rankings persist
after re-running analysis, defeating the point of the clear action.

## Changes

### Shared delete helper

- New package-local \`deleteVLMDataForFolderTx(tx, folderPath)\` runs the
  three VLM DELETEs on an existing \`*sql.Tx\`. Both public methods compose
  it rather than duplicating the SQL, so adding or renaming a VLM table
  in the future is a one-line change.
- \`DeleteVLMDataForFolder\` and \`DeleteAIDataForFolder\` each acquire
  \`s.mu\`, open a transaction, and delegate the VLM half to the helper.
  Reusing the public \`DeleteVLMDataForFolder\` from inside
  \`DeleteAIDataForFolder\` would deadlock on the mutex — the helper avoids
  that trap by design.

### Transactional atomicity

- Both methods now wrap their DELETEs in a single transaction. A mid-clear
  failure used to leave the folder in a half-cleared state (ai_scores
  gone but vlm_rankings still present, or rankings wiped but scores
  still attached to the now-missing group). With \`Begin\`/\`Commit\`/\`Rollback\`
  the clear is all-or-nothing.

## Test

\`TestDeleteAIDataForFolderClearsVLM\` is the regression test:

1. Seeds every affected table for a target folder AND a sibling "keep"
   folder: \`ai_scores\`, \`face_detections\`, \`face_clusters\`, \`vlm_scores\`,
   \`vlm_rankings\`, \`vlm_ranking_groups\`.
2. Runs \`DeleteAIDataForFolder(target)\`.
3. Asserts all six tables are empty for the target folder, tagging the
   failure message with "#116 regression" so a future break surfaces the
   right issue.
4. Asserts the sibling folder's rows are unchanged across all six tables,
   guarding against over-broad DELETEs.

## Test plan

- [x] \`go build ./internal/...\`
- [x] \`go test -race ./internal/...\`
- [x] \`go vet ./internal/...\`
- [x] \`gofmt -l\` clean on touched files
- [x] \`internal/storage\` coverage 75.5%
- [ ] CI green on push