### PR TITLE
perf(storage): collapse GetVLMRankingsForFolder N+1 pattern into one LEFT JOIN

### DIFF
--- a/internal/storage/sqlite.go
+++ b/internal/storage/sqlite.go
@@ -1145,47 +1145,76 @@ func (s *SQLiteStore) GetVLMRankingsForFolder(folderPath string) ([]VLMRankingGr
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	groupRows, err := s.db.Query(
-		`SELECT folder_path, group_label, photo_count, explanation, model_name, prompt_version
-		 FROM vlm_ranking_groups WHERE folder_path = ?`, folderPath,
+	// Single LEFT JOIN instead of the previous 1+N query pattern. The old
+	// shape issued one "list groups" query followed by a "list rankings"
+	// query per group, all while holding s.mu.RLock — with one write
+	// transaction blocked for the whole fan-out. This version fetches the
+	// flattened group×ranking tuple set once and aggregates in-memory.
+	//
+	// ORDER BY group_label keeps rows for a given group contiguous so the
+	// map-less aggregator below can preserve insertion order without a
+	// second pass. Within a group, ORDER BY rank ASC matches the previous
+	// per-group sort. SQLite orders NULLs first by default, which places
+	// the synthetic NULL row for an empty group (zero rankings) at the
+	// top of its group block — we skip it via photoPath.Valid.
+	rows, err := s.db.Query(
+		`SELECT g.folder_path, g.group_label, g.photo_count, g.explanation, g.model_name, g.prompt_version,
+		        r.photo_path, r.rank, r.relative_score, r.notes, r.tokens_used
+		   FROM vlm_ranking_groups g
+		   LEFT JOIN vlm_rankings r
+		     ON g.folder_path = r.folder_path AND g.group_label = r.group_label
+		  WHERE g.folder_path = ?
+		  ORDER BY g.group_label, r.rank ASC`,
+		folderPath,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get VLM ranking groups: %w", err)
+		return nil, fmt.Errorf("failed to query VLM rankings: %w", err)
 	}
-	defer func() { _ = groupRows.Close() }()
+	defer func() { _ = rows.Close() }()
 
+	// groupIndex maps group_label -> index in groups so we can append new
+	// ranking rows without a second lookup pass. Contiguous-by-group
+	// ordering means the map never grows beyond the distinct group count.
+	groupIndex := make(map[string]int)
 	var groups []VLMRankingGroupRow
-	for groupRows.Next() {
-		var g VLMRankingGroupRow
-		if err := groupRows.Scan(&g.FolderPath, &g.GroupLabel, &g.PhotoCount, &g.Explanation, &g.ModelName, &g.PromptVersion); err != nil {
-			return nil, fmt.Errorf("failed to scan VLM ranking group: %w", err)
-		}
-		groups = append(groups, g)
-	}
-	if err := groupRows.Err(); err != nil {
-		return nil, fmt.Errorf("VLM ranking groups iteration error: %w", err)
-	}
 
-	for i, g := range groups {
-		rankRows, err := s.db.Query(
-			`SELECT photo_path, rank, relative_score, notes, tokens_used
-			 FROM vlm_rankings WHERE folder_path = ? AND group_label = ? ORDER BY rank ASC`,
-			g.FolderPath, g.GroupLabel,
+	for rows.Next() {
+		var g VLMRankingGroupRow
+		var (
+			photoPath  sql.NullString
+			rank       sql.NullInt64
+			relScore   sql.NullFloat64
+			notes      sql.NullString
+			tokensUsed sql.NullInt64
 		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get VLM rankings for group %s: %w", g.GroupLabel, err)
+		if err := rows.Scan(
+			&g.FolderPath, &g.GroupLabel, &g.PhotoCount, &g.Explanation, &g.ModelName, &g.PromptVersion,
+			&photoPath, &rank, &relScore, &notes, &tokensUsed,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan VLM ranking row: %w", err)
 		}
-		var rankings []VLMRankingRow
-		for rankRows.Next() {
-			var r VLMRankingRow
-			if err := rankRows.Scan(&r.PhotoPath, &r.Rank, &r.RelativeScore, &r.Notes, &r.TokensUsed); err != nil {
-				_ = rankRows.Close()
-				return nil, fmt.Errorf("failed to scan VLM ranking row: %w", err)
-			}
-			rankings = append(rankings, r)
+
+		idx, ok := groupIndex[g.GroupLabel]
+		if !ok {
+			idx = len(groups)
+			groupIndex[g.GroupLabel] = idx
+			groups = append(groups, g)
 		}
-		_ = rankRows.Close()
-		groups[i].Rankings = rankings
+		// A group with zero rankings still produces one row (NULL ranking
+		// columns) from the LEFT JOIN. Skip those so empty groups end up
+		// with a nil Rankings slice instead of a phantom zero-value row.
+		if photoPath.Valid {
+			groups[idx].Rankings = append(groups[idx].Rankings, VLMRankingRow{
+				PhotoPath:     photoPath.String,
+				Rank:          int(rank.Int64),
+				RelativeScore: relScore.Float64,
+				Notes:         notes.String,
+				TokensUsed:    int(tokensUsed.Int64),
+			})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("VLM rankings iteration error: %w", err)
 	}
 
 	return groups, nil

--- a/internal/storage/sqlite_vlm_test.go
+++ b/internal/storage/sqlite_vlm_test.go
@@ -391,6 +391,136 @@ func TestSaveAndGetVLMRanking(t *testing.T) {
 	}
 }
 
+// TestGetVLMRankingsForFolderMultipleGroups asserts that several ranking
+// groups with different photo counts and rank orderings round-trip through
+// the rewritten LEFT JOIN query. Previously each group was fetched in its
+// own follow-up query — this test is the contract that the aggregator
+// behind the single JOIN produces the same shape.
+func TestGetVLMRankingsForFolderMultipleGroups(t *testing.T) {
+	store := newTestStore(t)
+
+	folder := "/photos/event"
+
+	// Group 1: three ranked photos, out-of-insertion order to exercise
+	// the ORDER BY r.rank clause.
+	group1 := VLMRankingGroupRow{
+		FolderPath: folder, GroupLabel: "cluster-A", PhotoCount: 3,
+		Explanation: "primary cluster", ModelName: "gemma-4", PromptVersion: 1,
+		Rankings: []VLMRankingRow{
+			{PhotoPath: folder + "/a3.jpg", Rank: 3, RelativeScore: 0.6, TokensUsed: 40},
+			{PhotoPath: folder + "/a1.jpg", Rank: 1, RelativeScore: 0.9, Notes: "sharpest", TokensUsed: 50},
+			{PhotoPath: folder + "/a2.jpg", Rank: 2, RelativeScore: 0.75, TokensUsed: 45},
+		},
+	}
+	// Group 2: two ranked photos in a different cluster, same folder.
+	group2 := VLMRankingGroupRow{
+		FolderPath: folder, GroupLabel: "cluster-B", PhotoCount: 2,
+		Explanation: "secondary cluster", ModelName: "gemma-4", PromptVersion: 1,
+		Rankings: []VLMRankingRow{
+			{PhotoPath: folder + "/b1.jpg", Rank: 1, RelativeScore: 0.85, Notes: "clean", TokensUsed: 40},
+			{PhotoPath: folder + "/b2.jpg", Rank: 2, RelativeScore: 0.70, TokensUsed: 40},
+		},
+	}
+	// Group in a different folder — must not appear in results.
+	other := VLMRankingGroupRow{
+		FolderPath: "/photos/other", GroupLabel: "cluster-X", PhotoCount: 1,
+		Explanation: "noise", ModelName: "gemma-4", PromptVersion: 1,
+		Rankings: []VLMRankingRow{
+			{PhotoPath: "/photos/other/x1.jpg", Rank: 1, RelativeScore: 0.5, TokensUsed: 30},
+		},
+	}
+
+	for _, g := range []VLMRankingGroupRow{group1, group2, other} {
+		if err := store.SaveVLMRanking(g); err != nil {
+			t.Fatalf("SaveVLMRanking %s: %v", g.GroupLabel, err)
+		}
+	}
+
+	got, err := store.GetVLMRankingsForFolder(folder)
+	if err != nil {
+		t.Fatalf("GetVLMRankingsForFolder: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 groups, got %d (%v)", len(got), got)
+	}
+
+	byLabel := map[string]VLMRankingGroupRow{}
+	for _, g := range got {
+		byLabel[g.GroupLabel] = g
+	}
+
+	a := byLabel["cluster-A"]
+	if len(a.Rankings) != 3 {
+		t.Fatalf("cluster-A: expected 3 rankings, got %d", len(a.Rankings))
+	}
+	for i, want := range []int{1, 2, 3} {
+		if a.Rankings[i].Rank != want {
+			t.Errorf("cluster-A rankings[%d].Rank = %d, want %d (ORDER BY rank lost)",
+				i, a.Rankings[i].Rank, want)
+		}
+	}
+	if a.Rankings[0].Notes != "sharpest" {
+		t.Errorf("cluster-A rankings[0].Notes = %q, want \"sharpest\"", a.Rankings[0].Notes)
+	}
+
+	b := byLabel["cluster-B"]
+	if len(b.Rankings) != 2 {
+		t.Fatalf("cluster-B: expected 2 rankings, got %d", len(b.Rankings))
+	}
+	if b.Rankings[0].PhotoPath != folder+"/b1.jpg" {
+		t.Errorf("cluster-B rankings[0].PhotoPath = %q, want %q",
+			b.Rankings[0].PhotoPath, folder+"/b1.jpg")
+	}
+}
+
+// TestGetVLMRankingsForFolderEmptyGroup covers the LEFT JOIN edge case: a
+// group row with no matching ranking rows produces one tuple with NULL
+// ranking columns. The aggregator must leave Rankings nil rather than
+// appending a phantom zero-valued VLMRankingRow.
+func TestGetVLMRankingsForFolderEmptyGroup(t *testing.T) {
+	store := newTestStore(t)
+
+	folder := "/photos/empty-group"
+	// Insert the group row directly without any ranking rows so the
+	// LEFT JOIN has to synthesize NULLs on the right side.
+	store.mu.Lock()
+	_, err := store.db.Exec(
+		`INSERT INTO vlm_ranking_groups (folder_path, group_label, photo_count, explanation, model_name, prompt_version)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		folder, "orphan", 0, "seeded for edge-case test", "gemma-4", 1,
+	)
+	store.mu.Unlock()
+	if err != nil {
+		t.Fatalf("seed orphan group: %v", err)
+	}
+
+	got, err := store.GetVLMRankingsForFolder(folder)
+	if err != nil {
+		t.Fatalf("GetVLMRankingsForFolder: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(got))
+	}
+	if len(got[0].Rankings) != 0 {
+		t.Errorf("empty group produced %d rankings, want 0 (LEFT JOIN NULL leaked)",
+			len(got[0].Rankings))
+	}
+}
+
+// TestGetVLMRankingsForFolderNoGroups asserts an empty result for a folder
+// with no ranking groups at all — not an error, just a zero-length slice.
+func TestGetVLMRankingsForFolderNoGroups(t *testing.T) {
+	store := newTestStore(t)
+
+	got, err := store.GetVLMRankingsForFolder("/no/such/folder")
+	if err != nil {
+		t.Fatalf("GetVLMRankingsForFolder: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 groups, got %d", len(got))
+	}
+}
+
 func TestRecordTokenUsage(t *testing.T) {
 	store := newTestStore(t)
 


### PR DESCRIPTION
## Summary

Closes #119.

\`GetVLMRankingsForFolder\` used to issue one query to list ranking groups
and then one follow-up query per group to fetch its rankings, all while
holding \`s.mu.RLock\`. For a folder with N face clusters that is 1+N
round-trips per UI read, and any concurrent write was blocked behind the
read lock for the full fan-out. With \`MaxOpenConns=4\` this never
deadlocked, but the lock hold time scaled linearly with cluster count.

## Changes

### Single \`LEFT JOIN\`

Replaces the fan-out with one query:

\`\`\`sql
SELECT g.folder_path, g.group_label, g.photo_count, g.explanation, g.model_name, g.prompt_version,
       r.photo_path, r.rank, r.relative_score, r.notes, r.tokens_used
  FROM vlm_ranking_groups g
  LEFT JOIN vlm_rankings r
    ON g.folder_path = r.folder_path AND g.group_label = r.group_label
 WHERE g.folder_path = ?
 ORDER BY g.group_label, r.rank ASC
\`\`\`

- \`ORDER BY g.group_label\` keeps rows for the same group contiguous so
  the aggregator runs in a single pass with no re-sort.
- \`ORDER BY r.rank ASC\` preserves the previous per-group ordering.

### In-memory aggregator

- \`groupIndex map[string]int\` maps each seen \`group_label\` to its index
  in the output slice — O(1) append with no per-row scan.
- The \`LEFT JOIN\` emits one row with NULL ranking columns for groups
  that have no rankings. Those are filtered via \`photoPath.Valid\` so
  empty groups come back with a nil \`Rankings\` slice, not a phantom
  zero-value row.

## Tests

- \`TestGetVLMRankingsForFolderMultipleGroups\`: two groups with
  mixed insertion/rank ordering round-trip correctly; a third group in
  a different folder is correctly excluded. Asserts \`rank\` ordering is
  preserved (catches \`ORDER BY rank\` regressions) and that per-row
  fields like \`Notes\` reach the caller unchanged.
- \`TestGetVLMRankingsForFolderEmptyGroup\`: seeds a group row
  directly without any rankings (raw \`INSERT\` into
  \`vlm_ranking_groups\`) so the \`LEFT JOIN\` has to synthesize NULLs.
  Asserts the result contains that group with exactly zero rankings —
  catches the "phantom zero-valued row" regression.
- \`TestGetVLMRankingsForFolderNoGroups\`: an unknown folder returns an
  empty slice and no error.

## Test plan

- [x] \`go build ./internal/...\`
- [x] \`go test -race ./internal/...\`
- [x] \`go vet ./internal/...\`
- [x] \`gofmt -l\` clean on touched files
- [x] \`internal/storage\` coverage 75.8%
- [ ] CI green on push