### PR TITLE
security(vlm): document upstream mlx_vlm api-key gap (fixes #115)

### DIFF
--- a/internal/vlm/mlx_backend.go
+++ b/internal/vlm/mlx_backend.go
@@ -110,10 +110,23 @@ func (b *MLXBackend) Start(ctx context.Context) error {
 	b.port = port
 
 	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
-	// MLX server has no auth token.
+	// Upstream mlx_vlm.server exposes no --api-key flag and performs no
+	// Authorization header checks (verified against Blaizzy/mlx-vlm main, 2026-04-18).
+	// Unlike llama-server (llamacpp_backend.go:123), we cannot generate and enforce
+	// a session token here. Mitigations in place:
+	//   1. Server binds to 127.0.0.1 only (see --host below), not reachable off-host.
+	//   2. ModelEntry.Available is false for MLX entries pending #128 — users do
+	//      not reach this code path in the shipping build.
+	// Residual risk: any local process running as the same user can issue
+	// requests to the MLX server port while it is running. Tracked as #115.
+	// Upstream contribution to add --api-key support would remove this gap.
 	b.client = NewClient(baseURL, "", b.modelEntry.Name)
 
 	if logger.Log != nil {
+		logger.Log.Warn("vlm: mlx: starting server WITHOUT api-key auth; upstream mlx_vlm.server lacks --api-key support (issue #115)",
+			slog.Int("port", port),
+			slog.String("bind", "127.0.0.1"),
+		)
 		logger.Log.Debug("vlm: mlx: launching server",
 			slog.String("python3", python3),
 			slog.String("model", b.modelPath),


### PR DESCRIPTION
## Summary
- Research outcome: upstream `Blaizzy/mlx-vlm` `mlx_vlm/server.py` on `main` (verified 2026-04-18) has no `--api-key` flag and no `Authorization` / `Bearer` checks. Client-side token generation would be ignored by the server.
- `internal/vlm/mlx_backend.go`: expanded the inline comment at the empty-token `NewClient` call to record the upstream gap, existing mitigations, residual risk, and the unblocking path (upstream contribution).
- Added a `Warn` log on every MLX `Start()` so operators see the unauthenticated-port state at runtime.

## Mitigations already in place
1. Server binds `--host 127.0.0.1` (loopback only, not network-reachable).
2. `ModelEntry.Available = false` for MLX entries pending #128 — MLX backend is not user-selectable in the shipping build.

## Residual risk
While the MLX subprocess is running, any local process as the same user can reach `127.0.0.1:{port}` and issue inference requests. Revisit when #128 lands and MLX becomes user-selectable.

## Test plan
- [x] `go build ./...` — green
- [x] `go test ./internal/vlm/...` — PASS
- [x] `golangci-lint fmt ./internal/vlm/...` + `run` — 0 issues