### PR TITLE
enhance(vlm): retry Start on port TOCTOU race (fixes #118)

### DIFF
--- a/internal/vlm/llamacpp_backend.go
+++ b/internal/vlm/llamacpp_backend.go
@@ -15,15 +15,16 @@ import (
 )
 
 const (
-	llamaCppBackendName   = "llamacpp"
-	llamaCppCtxSize       = 4096
-	llamaCppGPULayers     = 99
-	llamaCppReadyTimeout  = 60 * time.Second
-	llamaCppReadyPoll     = 500 * time.Millisecond
-	llamaCppStopGrace     = 5 * time.Second
-	llamaCppTokenBytesLen = 32
-	llamaCppMaxImages     = 5
-	llamaCppHost          = "127.0.0.1"
+	llamaCppBackendName     = "llamacpp"
+	llamaCppCtxSize         = 4096
+	llamaCppGPULayers       = 99
+	llamaCppReadyTimeout    = 60 * time.Second
+	llamaCppReadyPoll       = 500 * time.Millisecond
+	llamaCppStopGrace       = 5 * time.Second
+	llamaCppTokenBytesLen   = 32
+	llamaCppMaxImages       = 5
+	llamaCppHost            = "127.0.0.1"
+	llamaCppMaxStartRetries = 3
 )
 
 var llamaCppDefaultTokenBudgets = []int{70, 140, 280, 560, 1120}
@@ -86,6 +87,9 @@ func (b *LlamaCppBackend) ModelInfo() ModelInfo {
 }
 
 // Start launches the llama-server subprocess and waits for it to be ready.
+// Wraps startOnceLocked in a bounded retry loop so a rare TOCTOU port
+// collision between findFreePort() and subprocess bind cannot strand the
+// caller on a 60s waitForReady timeout.
 func (b *LlamaCppBackend) Start(ctx context.Context) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -113,16 +117,45 @@ func (b *LlamaCppBackend) Start(ctx context.Context) error {
 		return fmt.Errorf("vlm: llamacpp: model not found at %q: %w", b.modelPath, err)
 	}
 
+	var lastErr error
+	for attempt := 1; attempt <= llamaCppMaxStartRetries; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		err, retriable := b.startOnceLocked(ctx)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !retriable {
+			return err
+		}
+		if logger.Log != nil {
+			logger.Log.Warn("vlm: llamacpp: start attempt failed, retrying",
+				slog.Int("attempt", attempt),
+				slog.Int("maxAttempts", llamaCppMaxStartRetries),
+				slog.Any("err", err),
+			)
+		}
+	}
+	return fmt.Errorf("vlm: llamacpp: failed after %d start attempts: %w", llamaCppMaxStartRetries, lastErr)
+}
+
+// startOnceLocked performs a single launch attempt. Must be called with b.mu held.
+// The bool return indicates whether the caller should retry: true for failures
+// after cmd.Start() succeeded (covers port TOCTOU, transient subprocess crashes),
+// false for pre-exec failures (port alloc, token gen, pipe setup, cmd.Start).
+func (b *LlamaCppBackend) startOnceLocked(ctx context.Context) (error, bool) {
 	// Find a free port.
 	port, err := findFreePort()
 	if err != nil {
-		return fmt.Errorf("vlm: llamacpp: find free port: %w", err)
+		return fmt.Errorf("vlm: llamacpp: find free port: %w", err), false
 	}
 
 	// Generate a session token.
 	token, err := generateSessionToken()
 	if err != nil {
-		return fmt.Errorf("vlm: llamacpp: generate session token: %w", err)
+		return fmt.Errorf("vlm: llamacpp: generate session token: %w", err), false
 	}
 
 	args := []string{
@@ -150,12 +183,12 @@ func (b *LlamaCppBackend) Start(ctx context.Context) error {
 	stderrPipe, pipeErr := cmd.StderrPipe()
 	if pipeErr != nil {
 		cancelStderr()
-		return fmt.Errorf("vlm: llamacpp: create stderr pipe: %w", pipeErr)
+		return fmt.Errorf("vlm: llamacpp: create stderr pipe: %w", pipeErr), false
 	}
 
 	if startErr := cmd.Start(); startErr != nil {
 		cancelStderr()
-		return fmt.Errorf("vlm: llamacpp: start process: %w", startErr)
+		return fmt.Errorf("vlm: llamacpp: start process: %w", startErr), false
 	}
 
 	// Capture stderr into a bounded ring for crash diagnostics, while still logging live.
@@ -212,7 +245,9 @@ func (b *LlamaCppBackend) Start(ctx context.Context) error {
 		b.cancelStderr = nil
 		b.procDone = nil
 		b.stderrBuf = nil
-		return fmt.Errorf("vlm: llamacpp: server did not become ready: %w", err)
+		// Caller context cancellation is terminal — do not retry on the caller's behalf.
+		retriable := ctx.Err() == nil
+		return fmt.Errorf("vlm: llamacpp: server did not become ready: %w", err), retriable
 	}
 
 	b.client = NewClient(baseURL, token, b.modelEntry.Name)
@@ -224,7 +259,7 @@ func (b *LlamaCppBackend) Start(ctx context.Context) error {
 		)
 	}
 
-	return nil
+	return nil, false
 }
 
 // waitForReady polls /health until the server responds OK, the deadline expires,

--- a/internal/vlm/llamacpp_backend_test.go
+++ b/internal/vlm/llamacpp_backend_test.go
@@ -3,6 +3,7 @@ package vlm
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -332,7 +333,8 @@ func TestLlamaCppBackendRankPhotosParseFail(t *testing.T) {
 
 // TestLlamaCppBackendStartDetectsImmediateCrash verifies that when the subprocess
 // exits immediately (e.g. bad binary, model incompatibility), Start returns within
-// a few seconds rather than waiting the full 60s waitForReady timeout.
+// a few seconds rather than waiting the full 60s waitForReady timeout, even with
+// the retry loop trying llamaCppMaxStartRetries times.
 func TestLlamaCppBackendStartDetectsImmediateCrash(t *testing.T) {
 	falseBin := ""
 	for _, candidate := range []string{"/usr/bin/false", "/bin/false"} {
@@ -367,12 +369,73 @@ func TestLlamaCppBackendStartDetectsImmediateCrash(t *testing.T) {
 	if err == nil {
 		t.Fatal("Start() should fail when subprocess exits immediately")
 	}
+	// Even with llamaCppMaxStartRetries crash-detection cycles, each attempt
+	// terminates as soon as procDone closes, so total wallclock stays small.
 	if elapsed > 5*time.Second {
 		t.Errorf("Start() took %v detecting crash; expected <5s (regression in procDone detection)", elapsed)
 	}
 	msg := err.Error()
 	if !strings.Contains(msg, "crashed") && !strings.Contains(msg, "exited") {
 		t.Errorf("error should indicate subprocess crash/exit, got: %v", err)
+	}
+}
+
+// TestLlamaCppBackendStartRetriesOnReadyFailure verifies that waitForReady
+// failures are retried llamaCppMaxStartRetries times before surfacing, so a
+// TOCTOU port collision (or other transient startup error) does not leave the
+// caller stuck on a single 60s timeout.
+func TestLlamaCppBackendStartRetriesOnReadyFailure(t *testing.T) {
+	falseBin := ""
+	for _, candidate := range []string{"/usr/bin/false", "/bin/false"} {
+		if _, err := os.Stat(candidate); err == nil {
+			falseBin = candidate
+			break
+		}
+	}
+	if falseBin == "" {
+		t.Skip("no `false` binary available on this platform")
+	}
+
+	tmpModel := filepath.Join(t.TempDir(), "fake.gguf")
+	if err := os.WriteFile(tmpModel, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write fake model: %v", err)
+	}
+
+	b := NewLlamaCppBackend(falseBin, tmpModel, ModelEntry{
+		Name: "retry-test", Variant: "q", Backend: "llamacpp",
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := b.Start(ctx)
+	if err == nil {
+		t.Fatal("Start() should fail when every attempt crashes")
+	}
+	want := fmt.Sprintf("failed after %d start attempts", llamaCppMaxStartRetries)
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error should mention retry exhaustion %q, got: %v", want, err)
+	}
+}
+
+// TestLlamaCppBackendStartNonRetriableErrorsSkipRetries verifies that pre-exec
+// failures (missing binary, missing model) return immediately without wrapping
+// in the "failed after N start attempts" envelope — the retry loop is reserved
+// for transient post-exec failures.
+func TestLlamaCppBackendStartNonRetriableErrorsSkipRetries(t *testing.T) {
+	// Missing binary: stat fails before the retry loop even begins.
+	b := NewLlamaCppBackend("/nonexistent/llama-server", "/nonexistent/model.gguf", ModelEntry{
+		Name: "missing-test", Variant: "q", Backend: "llamacpp",
+	})
+	err := b.Start(context.Background())
+	if err == nil {
+		t.Fatal("Start() with missing binary should error")
+	}
+	if strings.Contains(err.Error(), "failed after") {
+		t.Errorf("missing-binary error should not be wrapped in retry envelope, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "binary not found") {
+		t.Errorf("error should mention missing binary, got: %v", err)
 	}
 }
 

--- a/internal/vlm/mlx_backend.go
+++ b/internal/vlm/mlx_backend.go
@@ -20,6 +20,7 @@ const (
 	mlxReadyPollInterval = 1 * time.Second
 	mlxReadyDeadline     = 120 * time.Second
 	mlxTokenBudgetBase   = 70
+	mlxMaxStartRetries   = 3
 )
 
 // mlxTokenBudgets is the standard token-budget ladder for VLM calls.
@@ -81,6 +82,9 @@ func (b *MLXBackend) ModelInfo() ModelInfo {
 
 // Start verifies prerequisites, allocates a port, and launches the mlx_vlm.server
 // subprocess. It blocks until the server is ready or the context deadline is reached.
+// Wraps startOnceLocked in a bounded retry loop so a rare TOCTOU port collision
+// between findFreePort() and subprocess bind cannot strand the caller on a 120s
+// waitForReady timeout.
 func (b *MLXBackend) Start(ctx context.Context) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -103,9 +107,37 @@ func (b *MLXBackend) Start(ctx context.Context) error {
 		return fmt.Errorf("vlm: mlx: model not found at %q (%w)", b.modelPath, err)
 	}
 
+	var lastErr error
+	for attempt := 1; attempt <= mlxMaxStartRetries; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		err, retriable := b.startOnceLocked(ctx, python3)
+		if err == nil {
+			return nil
+		}
+		lastErr = err
+		if !retriable {
+			return err
+		}
+		if logger.Log != nil {
+			logger.Log.Warn("vlm: mlx: start attempt failed, retrying",
+				slog.Int("attempt", attempt),
+				slog.Int("maxAttempts", mlxMaxStartRetries),
+				slog.Any("err", err),
+			)
+		}
+	}
+	return fmt.Errorf("vlm: mlx: failed after %d start attempts: %w", mlxMaxStartRetries, lastErr)
+}
+
+// startOnceLocked performs a single launch attempt. Must be called with b.mu held.
+// Returns retriable=true only for waitForReady failures (which cover port TOCTOU and
+// transient subprocess crashes); pipe/exec failures are not retried.
+func (b *MLXBackend) startOnceLocked(ctx context.Context, python3 string) (error, bool) {
 	port, err := findFreePort()
 	if err != nil {
-		return fmt.Errorf("vlm: mlx: find free port: %w", err)
+		return fmt.Errorf("vlm: mlx: find free port: %w", err), false
 	}
 	b.port = port
 
@@ -148,18 +180,18 @@ func (b *MLXBackend) Start(ctx context.Context) error {
 	// debugging) and retain a bounded tail for crash diagnostics.
 	stdoutPipe, soutErr := cmd.StdoutPipe()
 	if soutErr != nil {
-		return fmt.Errorf("vlm: mlx: stdout pipe: %w", soutErr)
+		return fmt.Errorf("vlm: mlx: stdout pipe: %w", soutErr), false
 	}
 	stderrPipe, serrErr := cmd.StderrPipe()
 	if serrErr != nil {
-		return fmt.Errorf("vlm: mlx: stderr pipe: %w", serrErr)
+		return fmt.Errorf("vlm: mlx: stderr pipe: %w", serrErr), false
 	}
 	stderrBuf := newBoundedBuffer(8192)
 	stderrCtx, cancelStderr := context.WithCancel(context.Background())
 
 	if startErr := cmd.Start(); startErr != nil {
 		cancelStderr()
-		return fmt.Errorf("vlm: mlx: start subprocess: %w", startErr)
+		return fmt.Errorf("vlm: mlx: start subprocess: %w", startErr), false
 	}
 
 	// Drain both pipes; tee into os.Stderr and into the ring.
@@ -216,13 +248,15 @@ func (b *MLXBackend) Start(ctx context.Context) error {
 		b.cancelStderr = nil
 		b.procDone = nil
 		b.stderrBuf = nil
-		return fmt.Errorf("vlm: mlx: server did not become ready: %w", readyErr)
+		// Caller context cancellation is terminal — do not retry on the caller's behalf.
+		retriable := ctx.Err() == nil
+		return fmt.Errorf("vlm: mlx: server did not become ready: %w", readyErr), retriable
 	}
 
 	if logger.Log != nil {
 		logger.Log.Debug("vlm: mlx: server ready", slog.Int("port", port))
 	}
-	return nil
+	return nil, false
 }
 
 // waitForReady polls GET /v1/models every second until the server responds with

--- a/internal/vlm/mlx_backend_test.go
+++ b/internal/vlm/mlx_backend_test.go
@@ -4,6 +4,7 @@ package vlm
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -61,5 +62,46 @@ func TestMLXBackendStartDetectsImmediateCrash(t *testing.T) {
 	// The stderr tail captured from the fake python should surface in the error.
 	if !strings.Contains(msg, "mlx_vlm import failed") {
 		t.Logf("warning: stderr tail missing from error (may be a timing edge) — got: %v", err)
+	}
+}
+
+// TestMLXBackendStartRetriesOnReadyFailure verifies that waitForReady failures
+// are retried mlxMaxStartRetries times before surfacing, so a TOCTOU port
+// collision or transient subprocess crash does not leave the caller stuck on a
+// single 120s timeout.
+func TestMLXBackendStartRetriesOnReadyFailure(t *testing.T) {
+	tmp := t.TempDir()
+
+	venv := filepath.Join(tmp, "venv")
+	binDir := filepath.Join(venv, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	fakePython := filepath.Join(binDir, "python3")
+	script := "#!/bin/sh\nexit 1\n"
+	if err := os.WriteFile(fakePython, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake python3: %v", err)
+	}
+
+	modelDir := filepath.Join(tmp, "model")
+	if err := os.MkdirAll(modelDir, 0o755); err != nil {
+		t.Fatalf("mkdir model: %v", err)
+	}
+
+	b := NewMLXBackend(venv, modelDir, ModelEntry{
+		Name: "mlx-retry-test", Variant: "4bit", Backend: "mlx",
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	err := b.Start(ctx)
+	if err == nil {
+		_ = b.Stop(context.Background())
+		t.Fatal("Start() should fail when every attempt crashes")
+	}
+	want := fmt.Sprintf("failed after %d start attempts", mlxMaxStartRetries)
+	if !strings.Contains(err.Error(), want) {
+		t.Errorf("error should mention retry exhaustion %q, got: %v", want, err)
 	}
 }


### PR DESCRIPTION
## Summary
- Wrap `Start` + `waitForReady` in a 3-attempt retry loop in both llamacpp and MLX backends.
- A rare TOCTOU race between `findFreePort()` closing its listener and the subprocess binding that port could otherwise strand callers on a 60s / 120s `waitForReady` timeout with a cryptic \"server not ready\" error.
- Only post-exec failures are retriable — stat checks, pipe setup, and `cmd.Start()` failures return immediately (environment problems, not port races). Caller ctx cancellation is terminal.

## Test plan
- [x] `go test ./internal/vlm/... -race -count=1` — all pass
- [x] `go test ./internal/... -race -count=1` — all pass
- [x] `golangci-lint run ./internal/vlm/...` — 0 issues
- [x] New: `TestLlamaCppBackendStartRetriesOnReadyFailure` — asserts retry envelope `\"failed after 3 start attempts\"`
- [x] New: `TestLlamaCppBackendStartNonRetriableErrorsSkipRetries` — missing binary bypasses retry loop
- [x] New: `TestMLXBackendStartRetriesOnReadyFailure` — same assertion for MLX (darwin/arm64)
- [x] Existing `TestLlamaCppBackendStartDetectsImmediateCrash` still finishes <5s with the retry loop — each attempt terminates as soon as `procDone` closes.

Closes #118